### PR TITLE
updateinfo: *_date attributes as Python datetime objects

### DIFF
--- a/tests/python/tests/test_updateinfo.py
+++ b/tests/python/tests/test_updateinfo.py
@@ -11,6 +11,9 @@ class TestCaseUpdateInfo(unittest.TestCase):
 
     def test_updateinfo_setters(self):
         now = datetime.now()
+        # Microseconds are always 0 in updateinfo
+        now = datetime(now.year, now.month, now.day, now.hour, now.minute,
+                       now.second, 0)
 
         ui = cr.UpdateInfo()
         self.assertTrue(ui)
@@ -24,8 +27,8 @@ class TestCaseUpdateInfo(unittest.TestCase):
         rec.version = "version"
         rec.id = "id"
         rec.title = "title"
-        rec.issued_date = now.strftime("%Y-%m-%d %H:%M:%S")
-        rec.updated_date = now.strftime("%Y-%m-%d %H:%M:%S")
+        rec.issued_date = now
+        rec.updated_date = now
         rec.rights = "rights"
         rec.release = "release"
         rec.pushcount = "pushcount"
@@ -45,8 +48,8 @@ class TestCaseUpdateInfo(unittest.TestCase):
         self.assertEqual(rec.version, "version")
         self.assertEqual(rec.id, "id")
         self.assertEqual(rec.title, "title")
-        self.assertEqual(rec.issued_date, now.strftime("%Y-%m-%d %H:%M:%S"))
-        self.assertEqual(rec.updated_date, now.strftime("%Y-%m-%d %H:%M:%S"))
+        self.assertEqual(rec.issued_date, now)
+        self.assertEqual(rec.updated_date, now)
         self.assertEqual(rec.rights, "rights")
         self.assertEqual(rec.release, "release")
         self.assertEqual(rec.pushcount, "pushcount")
@@ -66,6 +69,9 @@ class TestCaseUpdateInfo(unittest.TestCase):
 
     def test_updateinfo_xml_dump_02(self):
         now = datetime.now()
+        # Microseconds are always 0 in updateinfo
+        now = datetime(now.year, now.month, now.day, now.hour, now.minute,
+                       now.second, 0)
 
         ui = cr.UpdateInfo()
         xml = ui.xml_dump()
@@ -77,8 +83,8 @@ class TestCaseUpdateInfo(unittest.TestCase):
         rec.version = "version"
         rec.id = "id"
         rec.title = "title"
-        rec.issued_date = now.strftime("%Y-%m-%d %H:%M:%S")
-        rec.updated_date = now.strftime("%Y-%m-%d %H:%M:%S")
+        rec.issued_date = now
+        rec.updated_date = now
         rec.rights = "rights"
         rec.release = "release"
         rec.pushcount = "pushcount"
@@ -113,6 +119,9 @@ class TestCaseUpdateInfo(unittest.TestCase):
 
     def test_updateinfo_xml_dump_03(self):
         now = datetime.now()
+        # Microseconds are always 0 in updateinfo
+        now = datetime(now.year, now.month, now.day, now.hour, now.minute,
+                       now.second, 0)
 
         pkg = cr.UpdateCollectionPackage()
         pkg.name = "foo"
@@ -144,8 +153,8 @@ class TestCaseUpdateInfo(unittest.TestCase):
         rec.version = "version"
         rec.id = "id"
         rec.title = "title"
-        rec.issued_date = now.strftime("%Y-%m-%d %H:%M:%S")
-        rec.updated_date = now.strftime("%Y-%m-%d %H:%M:%S")
+        rec.issued_date = now
+        rec.updated_date = now
         rec.rights = "rights"
         rec.release = "release"
         rec.pushcount = "pushcount"

--- a/tests/python/tests/test_updaterecord.py
+++ b/tests/python/tests/test_updaterecord.py
@@ -11,6 +11,9 @@ class TestCaseUpdateRecord(unittest.TestCase):
 
     def test_updaterecord_setters(self):
         now = datetime.now()
+        # Microseconds are always 0 in updateinfo
+        now = datetime(now.year, now.month, now.day, now.hour, now.minute,
+                       now.second, 0)
 
         rec = cr.UpdateRecord()
         self.assertTrue(rec)
@@ -49,8 +52,8 @@ class TestCaseUpdateRecord(unittest.TestCase):
         rec.version = "version"
         rec.id = "id"
         rec.title = "title"
-        rec.issued_date = now.strftime("%Y-%m-%d %H:%M:%S")
-        rec.updated_date = now.strftime("%Y-%m-%d %H:%M:%S")
+        rec.issued_date = now
+        rec.updated_date = now
         rec.rights = "rights"
         rec.release = "release"
         rec.pushcount = "pushcount"
@@ -67,8 +70,8 @@ class TestCaseUpdateRecord(unittest.TestCase):
         self.assertEqual(rec.version, "version")
         self.assertEqual(rec.id, "id")
         self.assertEqual(rec.title, "title")
-        self.assertEqual(rec.issued_date, now.strftime("%Y-%m-%d %H:%M:%S"))
-        self.assertEqual(rec.updated_date, now.strftime("%Y-%m-%d %H:%M:%S"))
+        self.assertEqual(rec.issued_date, now)
+        self.assertEqual(rec.updated_date, now)
         self.assertEqual(rec.rights, "rights")
         self.assertEqual(rec.release, "release")
         self.assertEqual(rec.pushcount, "pushcount")
@@ -92,6 +95,9 @@ class TestCaseUpdateRecord(unittest.TestCase):
 
     def test_xml_dump_updaterecord(self):
         now = datetime.now()
+        # Microseconds are always 0 in updateinfo
+        now = datetime(now.year, now.month, now.day, now.hour, now.minute,
+                       now.second, 0)
 
         rec = cr.UpdateRecord()
         rec.fromstr = "from"
@@ -100,8 +106,8 @@ class TestCaseUpdateRecord(unittest.TestCase):
         rec.version = "version"
         rec.id = "id"
         rec.title = "title"
-        rec.issued_date = now.strftime("%Y-%m-%d %H:%M:%S")
-        rec.updated_date = now.strftime("%Y-%m-%d %H:%M:%S")
+        rec.issued_date = now
+        rec.updated_date = now
         rec.rights = "rights"
         rec.release = "release"
         rec.pushcount = "pushcount"


### PR DESCRIPTION
This makes the `UpdateRecord.issued_date` and `UpdateRecord.modified_date` be actual Python datetime objects, rather than plain strings.

A few caveats, on which I'd like feedback/pointers:
1. Internally, the structure still stores strings. That's because I didn't really want to modify the C API, only the Python one. So the getters and setters for these 2 attributes are doing the conversion.
2. The Python header inclusion (`#include <python2.7/datetime.h>`) is obviously wrong. Having never used cmake before, though, I can't seem to figure out how to include the proper header, based on the version of Python detected at build time. :confused:
3. In order to use Python datetime objects in a C extension, it is necessary to use the `PyDateTime_IMPORT` macro first. Currently, I'm calling it in the constructor of the `UpdateRecord` class, which is not necessarily ideal. Where would be the proper place to call it?

Other than that, it makes for a much nicer API:

```
>>> from datetime import datetime
>>> import createrepo_c as cr
>>> 
>>> up = cr.UpdateRecord()
>>> up.issued_date = datetime.now()
>>> 
>>> up.issued_date
datetime.datetime(2014, 8, 8, 18, 33, 32)
```
