### PR TITLE
Docs: Output python docs to separate directory

### DIFF
--- a/doc/python/CMakeLists.txt
+++ b/doc/python/CMakeLists.txt
@@ -1,5 +1,5 @@
 ADD_CUSTOM_TARGET (doc-python
     PYTHONPATH=${CMAKE_BINARY_DIR}/src/python sphinx-build -E -b html
-                  ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}
+                  ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/html
                   COMMENT "Building Python API documentation with Sphinx")
 


### PR DESCRIPTION
It makes it hard to package these docs when the CMake files are in the same
directory as the output. This patch moves the sphinx-build output to the
subdirectory "html".
