### PR TITLE
updateinfo: Fix a typo in the package release attribute

### DIFF
--- a/examples/python/updateinfo_parsing.py
+++ b/examples/python/updateinfo_parsing.py
@@ -40,7 +40,7 @@ def parse_updateinfo(path):
             for pkg in col.packages:
                 print "    Name:     %s" % pkg.name
                 print "    Version:  %s" % pkg.version
-                print "    Relase:   %s" % pkg.release
+                print "    Release:  %s" % pkg.release
                 print "    Epoch:    %s" % pkg.epoch
                 print "    Arch:     %s" % pkg.arch
                 print "    Src:      %s" % pkg.src

--- a/src/python/updaterecord-py.c
+++ b/src/python/updaterecord-py.c
@@ -370,7 +370,7 @@ static PyGetSetDef updaterecord_getsetters[] = {
     {"rights",                      (getter)get_str, (setter)set_str,
         "Copyrights",               OFFSET(rights)},
     {"release",                     (getter)get_str, (setter)set_str,
-        "Update relase",            OFFSET(release)},
+        "Update release",           OFFSET(release)},
     {"pushcount",                   (getter)get_str, (setter)set_str,
         "Pushcount",                OFFSET(pushcount)},
     {"severity",                    (getter)get_str, (setter)set_str,

--- a/src/xml_dump_updateinfo.c
+++ b/src/xml_dump_updateinfo.c
@@ -42,7 +42,7 @@ cr_xml_dump_updatecollectionpackages(xmlNodePtr collection, GSList *packages)
         package = xmlNewChild(collection, NULL, BAD_CAST "package", NULL);
         cr_xmlNewProp_c(package, BAD_CAST "name", BAD_CAST pkg->name);
         cr_xmlNewProp_c(package, BAD_CAST "version", BAD_CAST pkg->version);
-        cr_xmlNewProp_c(package, BAD_CAST "relase", BAD_CAST pkg->release);
+        cr_xmlNewProp_c(package, BAD_CAST "release", BAD_CAST pkg->release);
         cr_xmlNewProp_c(package, BAD_CAST "epoch", BAD_CAST pkg->epoch);
         cr_xmlNewProp_c(package, BAD_CAST "arch", BAD_CAST pkg->arch);
         cr_xmlNewProp_c(package, BAD_CAST "src", BAD_CAST pkg->src);

--- a/tests/python/tests/test_updateinfo.py
+++ b/tests/python/tests/test_updateinfo.py
@@ -190,7 +190,7 @@ class TestCaseUpdateInfo(unittest.TestCase):
     <pkglist>
       <collection short="short name">
         <name>long name</name>
-        <package name="foo" version="1.2" relase="3" epoch="0" arch="x86" src="foo.src.rpm">
+        <package name="foo" version="1.2" release="3" epoch="0" arch="x86" src="foo.src.rpm">
           <filename>foo.rpm</filename>
           <sum type="sha1">abcdef</sum>
           <reboot_suggested/>


### PR DESCRIPTION
I think this issue is causing yum to complain:

https://github.com/fedora-infra/bodhi/issues/275