### PR TITLE
fix traceback on non-complete datetime information (python)

### DIFF
--- a/src/python/updaterecord-py.c
+++ b/src/python/updaterecord-py.c
@@ -274,9 +274,12 @@ get_datetime(_UpdateRecordObject *self, void *member_offset)
 
     struct tm *dt = malloc(sizeof(struct tm));
     char *res = strptime(str, "%Y-%m-%d %H:%M:%S", dt);
-    if (res == NULL)
-        PyErr_SetString(CrErr_Exception, "Invalid date");
-
+    if (res == NULL) {
+        memset(res,0,sizeof(dt));
+        res = strptime(str, "%Y-%m-%d", dt);
+        if (res == NULL)
+           PyErr_SetString(CrErr_Exception, "Invalid date");
+        }
     PyObject *py_dt = PyDateTime_FromDateAndTime(dt->tm_year + 1900,
                                       dt->tm_mon + 1, dt->tm_mday,
                                       dt->tm_hour, dt->tm_min, dt->tm_sec, 0);


### PR DESCRIPTION
Some Red Hat advisories contain incomplete datetime information in "issued date" and/or "updated date" updateinfo.xml elements - YYYY-MM-DD instead of expected YYYY-MM-DD HH:MM:SS
attached patch prevents python Traceback on parsing such data.

Please consider adding the patch.

Best Regards

Jarek