### PR TITLE
Replace on_exit() call with atexit() call (Fixes FTBFS on Unity Linux)

### DIFF
--- a/src/createrepo_shared.c
+++ b/src/createrepo_shared.c
@@ -84,7 +84,7 @@ cr_set_cleanup_handler(const char *lock_dir,
         global_tmp_out_repo = NULL;
 
     // Register on exit cleanup function
-    if (on_exit(failure_exit_cleanup, NULL))
+    if (atexit(failure_exit_cleanup))
         g_warning("Cannot set exit cleanup function by atexit()");
 
     // Prepare signal handler configuration

--- a/src/createrepo_shared.h
+++ b/src/createrepo_shared.h
@@ -40,7 +40,7 @@ extern "C" {
 
 /**
  * This function does:
- * 1) Sets on_exit cleanup function that removes temporary directories
+ * 1) Sets atexit cleanup function that removes temporary directories
  * 2) Sets a signal handler for signals that lead to process temination.
  *    (List obtained from the "man 7 signal")
  *    Signals that are ignored (SIGCHILD) or lead just to stop (SIGSTOP, ...)


### PR DESCRIPTION
For [Unity Linux](http://unitylinux.com/index.php?id=about), we're using MUSL libc instead of glibc, so a great deal of non-standard and deprecated functions are not supported. This causes the createrepo_c build to fail because it uses `on_exit()`.

The `on_exit()` function is non-portable and is not available in all environments (notably Linux environments running on MUSL and Solaris based environments). 

Thus, the function call is swapped for the portable `atexit()` call.

The build and tests all pass after swapping `on_exit()` for `atexit()`.