### PR TITLE
Split option similar to python version of createrepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ deltarepo/acceptance_tests/repos/repo*/repodata
 BUG*/
 JIRA*/
 ISSUE*/
+
+# vim swap files
+*.sw?

--- a/src/cmd_parser.c
+++ b/src/cmd_parser.c
@@ -106,6 +106,8 @@ static GOptionEntry cmd_entries[] =
       "Skip the stat() call on a --update, assumes if the filename is the same "
       "then the file is still the same (only use this if you're fairly "
       "trusting or gullible).", NULL },
+    { "split", 0, 0, G_OPTION_ARG_NONE, &(_cmd_options.split),
+      "generate split media", NULL },
     { "pkglist", 'i', 0, G_OPTION_ARG_FILENAME, &(_cmd_options.pkglist),
       "Specify a text file which contains the complete list of files to "
       "include in the repository from the set found in the directory. File "

--- a/src/cmd_parser.h
+++ b/src/cmd_parser.h
@@ -46,6 +46,7 @@ struct CmdOptions {
     char **update_md_paths;     /*!< list of paths to repositories which should
                                      be used for update */
     gboolean skip_stat;         /*!< skip stat() call during --update */
+    gboolean split;         	/*!< generate split media */
     gboolean version;           /*!< print program version */
     gboolean database;          /*!< create sqlite database metadata */
     gboolean no_database;       /*!< do not create database */

--- a/src/cmd_parser.h
+++ b/src/cmd_parser.h
@@ -46,7 +46,7 @@ struct CmdOptions {
     char **update_md_paths;     /*!< list of paths to repositories which should
                                      be used for update */
     gboolean skip_stat;         /*!< skip stat() call during --update */
-    gboolean split;         	/*!< generate split media */
+    gboolean split;             /*!< generate split media */
     gboolean version;           /*!< print program version */
     gboolean database;          /*!< create sqlite database metadata */
     gboolean no_database;       /*!< do not create database */

--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -265,7 +265,7 @@ fill_pool(GThreadPool *pool,
         ++*package_count;
     }
 
-    return package_count;
+    return *package_count;
 }
 
 
@@ -818,7 +818,6 @@ main(int argc, char **argv)
     user_data.fil_db            = fil_db;
     user_data.oth_db            = oth_db;
     user_data.changelog_limit   = cmd_options->changelog_limit;
-    user_data.location_base     = cmd_options->location_base;
     user_data.checksum_type_str = cr_checksum_name_str(cmd_options->checksum_type);
     user_data.checksum_type     = cmd_options->checksum_type;
     user_data.checksum_cachedir = cmd_options->checksum_cachedir;
@@ -844,6 +843,11 @@ main(int argc, char **argv)
     user_data.deltatargetpackages = NULL;
     user_data.cut_dirs          = cmd_options->cut_dirs;
     user_data.location_prefix   = cmd_options->location_prefix;
+
+    if ( cmd_options->split && ! cmd_options->location_base)
+        user_data.location_base     = "media://";
+    else
+        user_data.location_base     = cmd_options->location_base;
 
     g_debug("Thread pool user data ready");
 

--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -346,7 +346,15 @@ main(int argc, char **argv)
         exit(EXIT_SUCCESS);
     }
 
-    if ( ! cmd_options->split ) {
+    if ( cmd_options->split ) {
+        if (argc < 2) {
+            g_printerr("Must specify at least one directory to index.\n");
+            g_printerr("Usage: %s [options] <directory_to_index> [directory_to_index] ...\n\n",
+                     cr_get_filename(argv[0]));
+            free_options(cmd_options);
+            exit(EXIT_FAILURE);
+        }
+    } else {
         if (argc != 2) {
             // No mandatory arguments
             g_printerr("Must specify exactly one directory to index.\n");

--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -147,7 +147,6 @@ fill_pool(GThreadPool *pool,
         GQueue *sub_dirs = g_queue_new();
         gchar *input_dir_stripped;
 
-
         input_dir_stripped = g_string_chunk_insert_len(sub_dirs_chunk,
                                                        in_dir,
                                                        in_dir_len-1);
@@ -206,9 +205,7 @@ fill_pool(GThreadPool *pool,
                     task->path = g_strdup(dirname);
                     if (output_pkg_list)
                         fprintf(output_pkg_list, "%s\n", repo_relative_path);
-
                     *current_pkglist = g_slist_prepend(*current_pkglist, task->filename);
-
                     // TODO: One common path for all tasks with the same path?
                     g_queue_insert_sorted(&queue, task, task_cmp, NULL);
                 } else {
@@ -376,6 +373,7 @@ main(int argc, char **argv)
         in_dir = cr_normalize_dir_path(argv[1]);
     }
 
+    // Check if inputdir exists
     if (!g_file_test(in_dir, G_FILE_TEST_IS_DIR)) {
         g_printerr("Directory %s must exist\n", in_dir);
         g_free(in_dir);
@@ -414,7 +412,6 @@ main(int argc, char **argv)
     if (!prepare_cache_dir(cmd_options, out_dir, &tmp_err)) {
         g_printerr("%s\n", tmp_err->message);
         g_error_free(tmp_err);
-
         g_free(in_dir);
         g_free(in_repo);
         g_free(out_dir);
@@ -423,7 +420,6 @@ main(int argc, char **argv)
         exit(EXIT_FAILURE);
     }
 
-    // Check if inputdir exists
     // Block signals that terminates the process
     if (!cr_block_terminating_signals(&tmp_err)) {
         g_printerr("%s\n", tmp_err->message);
@@ -454,7 +450,7 @@ main(int argc, char **argv)
         output_pkg_list = fopen(cmd_options->read_pkgs_list, "w");
         if (!output_pkg_list) {
             g_critical("Cannot open \"%s\" for writing: %s",
-                   cmd_options->read_pkgs_list, g_strerror(errno));
+                       cmd_options->read_pkgs_list, g_strerror(errno));
             exit(EXIT_FAILURE);
         }
     }
@@ -1330,7 +1326,6 @@ deltaerror:
     g_free(in_repo);
     g_free(out_repo);
     g_free(tmp_out_repo);
-// TODO M0ses: g_free must be done inside loop
     g_free(in_dir);
     g_free(out_dir);
     g_free(lock_dir);

--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -339,15 +339,19 @@ main(int argc, char **argv)
         exit(EXIT_SUCCESS);
     }
 
-    if (argc != 2) {
-        // No mandatory arguments
-        g_printerr("Must specify exactly one directory to index.\n");
-        g_printerr("Usage: %s [options] <directory_to_index>\n\n",
-                         cr_get_filename(argv[0]));
-        free_options(cmd_options);
-        exit(EXIT_FAILURE);
+    if ( ! cmd_options->split ) {
+	if (argc != 2) {
+	    // No mandatory arguments
+	    g_printerr("Must specify exactly one directory to index.\n");
+	    g_printerr("Usage: %s [options] <directory_to_index>\n\n",
+			     cr_get_filename(argv[0]));
+	    free_options(cmd_options);
+	    exit(EXIT_FAILURE);
+	}
     }
 
+// TODO M0ses: loop over argv for in_dir starts here
+// use tmp_in_dir
     // Dirs
     gchar *in_dir       = NULL;  // path/to/repo/
     gchar *in_repo      = NULL;  // path/to/repo/repodata/
@@ -358,15 +362,20 @@ main(int argc, char **argv)
 
     if (cmd_options->basedir && !g_str_has_prefix(argv[1], "/")) {
         gchar *tmp = cr_normalize_dir_path(argv[1]);
+// TODO M0ses : use tmp_in_dir
         in_dir = g_build_filename(cmd_options->basedir, tmp, NULL);
         g_free(tmp);
     } else {
+// TODO M0ses : use tmp_in_dir
         in_dir = cr_normalize_dir_path(argv[1]);
     }
 
     // Check if inputdir exists
+// TODO M0ses : use tmp_in_dir
     if (!g_file_test(in_dir, G_FILE_TEST_IS_DIR)) {
+// TODO M0ses : use tmp_in_dir
         g_printerr("Directory %s must exist\n", in_dir);
+// TODO M0ses : use tmp_in_dir
         g_free(in_dir);
         free_options(cmd_options);
         exit(EXIT_FAILURE);
@@ -374,9 +383,12 @@ main(int argc, char **argv)
 
 
     // Check parsed arguments
+// TODO M0ses : use tmp_in_dir
+// TODO M0ses : breakup check_arguments because doing this in loop makes no sense
     if (!check_arguments(cmd_options, in_dir, &tmp_err)) {
         g_printerr("%s\n", tmp_err->message);
         g_error_free(tmp_err);
+// TODO M0ses : use tmp_in_dir
         g_free(in_dir);
         free_options(cmd_options);
         exit(EXIT_FAILURE);
@@ -389,12 +401,14 @@ main(int argc, char **argv)
     g_debug("Version: %s", cr_version_string_with_features());
 
     // Set paths of input and output repos
+// TODO M0ses : use tmp_in_dir
     in_repo = g_strconcat(in_dir, "repodata/", NULL);
 
     if (cmd_options->outputdir) {
         out_dir = cr_normalize_dir_path(cmd_options->outputdir);
         out_repo = g_strconcat(out_dir, "repodata/", NULL);
     } else {
+// TODO M0ses : use tmp_in_dir
         out_dir  = g_strdup(in_dir);
         out_repo = g_strdup(in_repo);
     }
@@ -403,6 +417,7 @@ main(int argc, char **argv)
     if (!prepare_cache_dir(cmd_options, out_dir, &tmp_err)) {
         g_printerr("%s\n", tmp_err->message);
         g_error_free(tmp_err);
+// TODO M0ses : use tmp_in_dir
         g_free(in_dir);
         g_free(in_repo);
         g_free(out_dir);
@@ -467,6 +482,7 @@ main(int argc, char **argv)
 
 
     // Thread pool - Fill with tasks
+// TODO M0ses : use tmp_in_dir
     package_count = fill_pool(pool,
                               in_dir,
                               cmd_options,
@@ -495,6 +511,7 @@ main(int argc, char **argv)
         if (cmd_options->outputdir)
             old_metadata_location = cr_locate_metadata(out_dir, TRUE, NULL);
         else
+// TODO M0ses : use first argv instead of in_dir
             old_metadata_location = cr_locate_metadata(in_dir, TRUE, NULL);
 
         if (old_metadata_location) {
@@ -809,6 +826,8 @@ main(int argc, char **argv)
     user_data.checksum_type     = cmd_options->checksum_type;
     user_data.checksum_cachedir = cmd_options->checksum_cachedir;
     user_data.skip_symlinks     = cmd_options->skip_symlinks;
+// TODO M0ses : use first argv instead of in_dir
+// to be investigated
     user_data.repodir_name_len  = strlen(in_dir);
     user_data.package_count     = package_count;
     user_data.skip_stat         = cmd_options->skip_stat;
@@ -1309,6 +1328,7 @@ deltaerror:
     g_free(in_repo);
     g_free(out_repo);
     g_free(tmp_out_repo);
+// TODO M0ses: g_free must be done inside loop
     g_free(in_dir);
     g_free(out_dir);
     g_free(lock_dir);

--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -124,7 +124,7 @@ fill_pool(GThreadPool *pool,
           struct CmdOptions *cmd_options,
           GSList **current_pkglist,
           FILE *output_pkg_list,
-          long package_count,
+          long *package_count,
           int  media_id)
 {
     GQueue queue = G_QUEUE_INIT;
@@ -259,10 +259,10 @@ fill_pool(GThreadPool *pool,
 
     // Push sorted tasks into the thread pool
     while ((task = g_queue_pop_head(&queue)) != NULL) {
-        task->id = package_count;
+        task->id = *package_count;
         task->media_id = media_id;
         g_thread_pool_push(pool, task, NULL);
-        ++package_count;
+        ++*package_count;
     }
 
     return package_count;
@@ -475,19 +475,16 @@ main(int argc, char **argv)
     /* ^^^ List with basenames of files which will be processed */
 
     for (int media_id = 1; media_id < argc; media_id++ ) {
-    gchar *tmp_in_dir = cr_normalize_dir_path(argv[media_id]);
-    // Thread pool - Fill with tasks
-// TODO M0ses: looks ugly for me to get package_count back again
-// discuss better solutions
-        package_count = fill_pool(pool,
-                                  tmp_in_dir,
-                                  cmd_options,
-                                  &current_pkglist,
-                                  output_pkg_list,
-                                  package_count,
-                                  media_id);
+        gchar *tmp_in_dir = cr_normalize_dir_path(argv[media_id]);
+        // Thread pool - Fill with tasks
+        fill_pool(pool,
+                  tmp_in_dir,
+                  cmd_options,
+                  &current_pkglist,
+                  output_pkg_list,
+                  &package_count,
+                  media_id);
         g_free(tmp_in_dir);
-
     }
 
     g_debug("Package count: %ld", package_count);

--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -826,6 +826,7 @@ main(int argc, char **argv)
     user_data.fil_db            = fil_db;
     user_data.oth_db            = oth_db;
     user_data.changelog_limit   = cmd_options->changelog_limit;
+    user_data.location_base     = cmd_options->location_base;
     user_data.checksum_type_str = cr_checksum_name_str(cmd_options->checksum_type);
     user_data.checksum_type     = cmd_options->checksum_type;
     user_data.checksum_cachedir = cmd_options->checksum_cachedir;
@@ -851,8 +852,6 @@ main(int argc, char **argv)
     user_data.deltatargetpackages = NULL;
     user_data.cut_dirs          = cmd_options->cut_dirs;
     user_data.location_prefix   = cmd_options->location_prefix;
-
-    user_data.location_base     = cmd_options->location_base;
 
     g_debug("Thread pool user data ready");
 

--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -852,10 +852,7 @@ main(int argc, char **argv)
     user_data.cut_dirs          = cmd_options->cut_dirs;
     user_data.location_prefix   = cmd_options->location_prefix;
 
-    if ( cmd_options->split && ! cmd_options->location_base)
-        user_data.location_base     = "media://";
-    else
-        user_data.location_base     = cmd_options->location_base;
+    user_data.location_base     = cmd_options->location_base;
 
     g_debug("Thread pool user data ready");
 

--- a/src/dumper_thread.c
+++ b/src/dumper_thread.c
@@ -256,7 +256,7 @@ load_rpm(const char *fullpath,
         size_t lb_length = strlen(location_base);
         gchar *t_location_base = g_malloc0(lb_length + 32);
         strcpy(t_location_base, location_base);
-        if (lb_length > 2 && g_strcmp0(location_base + lb_length - 3, "://") == 0)
+        if (lb_length > 3 && g_strcmp0(location_base + lb_length - 3, "://") == 0)
             lb_length -= 2;
         sprintf(t_location_base + lb_length, "#%d", media_id);
         pkg->location_base = cr_safe_string_chunk_insert(pkg->chunk, t_location_base);

--- a/src/dumper_thread.c
+++ b/src/dumper_thread.c
@@ -244,13 +244,24 @@ load_rpm(const char *fullpath,
     if (!pkg)
         goto errexit;
 
-// TODO M0ses: clarify is this is really what was expected, looks very ugly to me
-    if ( g_strcmp0(location_base,"media://") == 0 && media_id > 0 ) {
-	sprintf(location_base,"media:#%i",media_id);
+    // cut off trailing slashes from urls e.g. media:// -> media:
+    gsize  lb_length       = strlen(location_base);
+    gchar  *t_location_base;
+    char suf[2];
+    strncpy(suf,&location_base[lb_length-2],2);
+
+    if ( g_strcmp0(suf,"//") == 0 ) {
+        t_location_base = g_strndup(location_base,lb_length-2);
+    } else {
+        t_location_base = g_strdup(location_base);
     }
 
+    // if --split option was given, the media_id == 0
+    if ( media_id > 0 )
+	    sprintf(t_location_base,"%s#%i",t_location_base,media_id);
+
     pkg->location_href = cr_safe_string_chunk_insert(pkg->chunk, location_href);
-    pkg->location_base = cr_safe_string_chunk_insert(pkg->chunk, location_base);
+    pkg->location_base = cr_safe_string_chunk_insert(pkg->chunk, t_location_base);
 
     // Get checksum type string
     pkg->checksum_type = cr_safe_string_chunk_insert(pkg->chunk,

--- a/src/dumper_thread.c
+++ b/src/dumper_thread.c
@@ -244,26 +244,26 @@ load_rpm(const char *fullpath,
     if (!pkg)
         goto errexit;
 
-    // cut off trailing slashes from urls e.g. media:// -> media:
-    gsize  lb_length        = strlen(location_base);
-    gchar  *t_location_base = g_malloc0(sizeof(location_base));
-    char suf[2];
-    strncpy(suf,&location_base[lb_length-2],2);
 
-    if ( g_strcmp0(suf,"//") == 0 ) {
-        t_location_base = g_strndup(location_base,lb_length-2);
+    if (!media_id) {
+        pkg->location_base = cr_safe_string_chunk_insert(pkg->chunk, location_base);
     } else {
-        t_location_base = g_strdup(location_base);
+        // default location_base "media:" in split mode
+        if (!location_base)
+            location_base = "media:";
+
+        // calculate location_base
+        size_t lb_length = strlen(location_base);
+        gchar *t_location_base = g_malloc0(lb_length + 32);
+        strcpy(t_location_base, location_base);
+        if (lb_length > 2 && g_strcmp0(location_base + lb_length - 3, "://") == 0)
+            lb_length -= 2;
+        sprintf(t_location_base + lb_length, "#%d", media_id);
+        pkg->location_base = cr_safe_string_chunk_insert(pkg->chunk, t_location_base);
+        g_free(t_location_base);
     }
 
-    // if --split option was given, the media_id == 0
-    if ( media_id > 0 )
-	    sprintf(t_location_base,"%s#%i",t_location_base,media_id);
-
     pkg->location_href = cr_safe_string_chunk_insert(pkg->chunk, location_href);
-    pkg->location_base = cr_safe_string_chunk_insert(pkg->chunk, t_location_base);
-
-    g_free(t_location_base);
 
     // Get checksum type string
     pkg->checksum_type = cr_safe_string_chunk_insert(pkg->chunk,

--- a/src/dumper_thread.c
+++ b/src/dumper_thread.c
@@ -323,7 +323,6 @@ errexit:
     return NULL;
 }
 
-
 void
 cr_dumper_thread(gpointer data, gpointer user_data)
 {

--- a/src/dumper_thread.c
+++ b/src/dumper_thread.c
@@ -431,10 +431,10 @@ cr_dumper_thread(gpointer data, gpointer user_data)
     } else {
         // Just gen XML from old loaded metadata
         if ( task->media_id ) {
-	    if ( ! md->chunk ) {
-		g_debug("Creating new chunk");
-		md->chunk = g_string_chunk_new (PACKAGE_CHUNK_SIZE);
-	    }
+            // need chunk to store location_base foreach package
+            if ( ! md->chunk )
+                md->chunk = g_string_chunk_new (PACKAGE_CHUNK_SIZE);
+
             prepare_split_media_baseurl(task->media_id, location_base, md);
         }
         pkg = md;
@@ -518,6 +518,8 @@ cr_dumper_thread(gpointer data, gpointer user_data)
     // Clean up
     if (pkg != md)
         cr_package_free(pkg);
+    else
+        g_string_chunk_free(md->chunk);
     g_free(res.primary);
     g_free(res.filelists);
     g_free(res.other);
@@ -565,6 +567,8 @@ task_cleanup:
             // Clean up
             if (!buf_task->pkg_from_md)
                 cr_package_free(buf_task->pkg);
+            else
+                g_string_chunk_free(buf_task->pkg->chunk);
             g_free(buf_task->res.primary);
             g_free(buf_task->res.filelists);
             g_free(buf_task->res.other);

--- a/src/dumper_thread.c
+++ b/src/dumper_thread.c
@@ -230,8 +230,8 @@ load_rpm(const char *fullpath,
          int changelog_limit,
          struct stat *stat_buf,
          cr_HeaderReadingFlags hdrrflags,
-         GError **err,
-         int media_id)
+         int media_id,
+         GError **err)
 {
     cr_Package *pkg = NULL;
     GError *tmp_err = NULL;
@@ -399,7 +399,7 @@ cr_dumper_thread(gpointer data, gpointer user_data)
         pkg = load_rpm(task->full_path, udata->checksum_type,
                        udata->checksum_cachedir, location_href,
                        udata->location_base, udata->changelog_limit,
-                       NULL, hdrrflags, &tmp_err,task->media_id);
+                       NULL, hdrrflags, task->media_id, &tmp_err);
         assert(pkg || tmp_err);
 
         if (!pkg) {

--- a/src/dumper_thread.c
+++ b/src/dumper_thread.c
@@ -245,8 +245,8 @@ load_rpm(const char *fullpath,
         goto errexit;
 
     // cut off trailing slashes from urls e.g. media:// -> media:
-    gsize  lb_length       = strlen(location_base);
-    gchar  *t_location_base;
+    gsize  lb_length        = strlen(location_base);
+    gchar  *t_location_base = g_malloc0(sizeof(location_base));
     char suf[2];
     strncpy(suf,&location_base[lb_length-2],2);
 
@@ -262,6 +262,8 @@ load_rpm(const char *fullpath,
 
     pkg->location_href = cr_safe_string_chunk_insert(pkg->chunk, location_href);
     pkg->location_base = cr_safe_string_chunk_insert(pkg->chunk, t_location_base);
+
+    g_free(t_location_base);
 
     // Get checksum type string
     pkg->checksum_type = cr_safe_string_chunk_insert(pkg->chunk,

--- a/src/dumper_thread.h
+++ b/src/dumper_thread.h
@@ -40,6 +40,7 @@ extern "C" {
 
 struct PoolTask {
     long  id;                       // ID of the task
+    long  media_id;                 // ID of media in split mode, 0 if not in split mode
     char* full_path;                // Complete path - /foo/bar/packages/foo.rpm
     char* filename;                 // Just filename - foo.rpm
     char* path;                     // Just path     - /foo/bar/packages

--- a/src/package.c
+++ b/src/package.c
@@ -22,8 +22,6 @@
 #include "package.h"
 #include "misc.h"
 
-#define PACKAGE_CHUNK_SIZE 2048
-
 cr_Dependency *
 cr_dependency_new(void)
 {

--- a/src/package.c
+++ b/src/package.c
@@ -22,6 +22,8 @@
 #include "package.h"
 #include "misc.h"
 
+#define PACKAGE_CHUNK_SIZE 2048
+
 cr_Dependency *
 cr_dependency_new(void)
 {

--- a/src/package.h
+++ b/src/package.h
@@ -28,6 +28,8 @@ extern "C" {
 
 #include <glib.h>
 
+#define PACKAGE_CHUNK_SIZE 2048
+
 /** \defgroup   package         Package representation.
  *  \addtogroup package
  *  @{

--- a/src/package.h
+++ b/src/package.h
@@ -28,8 +28,6 @@ extern "C" {
 
 #include <glib.h>
 
-#define PACKAGE_CHUNK_SIZE 2048
-
 /** \defgroup   package         Package representation.
  *  \addtogroup package
  *  @{


### PR DESCRIPTION
* createrepo_c supports now the "--split" option
* base url is set to "media:" by default if no "-u" option is set
* trailing double slashes will be cut off ( "media://" -> "media:")