### PR TITLE
Allow single repos in mergerepo_c

### DIFF
--- a/src/mergerepo_c.c
+++ b/src/mergerepo_c.c
@@ -402,7 +402,7 @@ parse_arguments(int *argc, char ***argv)
     GOptionContext *context;
 
     context = g_option_context_new("--repo=url --repo=url");
-    g_option_context_set_summary(context, "Take 2 or more repositories and "
+    g_option_context_set_summary(context, "Take one or more repositories and "
                                  "merge their metadata into a new repo");
     g_option_context_add_main_entries(context, cmd_entries, NULL);
 
@@ -1623,7 +1623,7 @@ main(int argc, char **argv)
         exit(0);
     }
 
-    if (g_slist_length(cmd_options->repo_list) < 2) {
+    if (g_slist_length(cmd_options->repo_list) < 1) {
         free_options(cmd_options);
         g_printerr("Usage: %s [OPTION...] --repo=url --repo=url\n\n"
                    "%s: take 2 or more repositories and merge their "


### PR DESCRIPTION
I'd like to use mergerepo_c for cloning repository metadata, adding a pointer to the original package location. However this functionality would also require running mergerepo_c with a single repo argument.

This patch removes the requirement for two repo arguments.