### PR TITLE
createrepo_c should exit nonzero if there are any errors.

### DIFF
--- a/src/cmd_parser.c
+++ b/src/cmd_parser.c
@@ -186,6 +186,8 @@ static GOptionEntry cmd_entries[] =
       "Append this prefix before location_href in output repodata", "PREFIX" },
     { "repomd-checksum", 0, 0, G_OPTION_ARG_STRING, &(_cmd_options.repomd_checksum),
       "Checksum type to be used in repomd.xml", "CHECKSUM_TYPE"},
+    { "error-exit-val", 0, 0, G_OPTION_ARG_NONE, &(_cmd_options.error_exit_val),
+      "Exit with retval 2 if there were any errors during processing", NULL },
     { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL },
 };
 

--- a/src/cmd_parser.h
+++ b/src/cmd_parser.h
@@ -105,6 +105,7 @@ struct CmdOptions {
     gchar *location_prefix;     /*!< Append this prefix into location_href
                                      during repodata generation. */
     gchar *repomd_checksum;     /*!< Checksum type for entries in repomd.xml */
+    gboolean error_exit_val;        /*!< exit 2 on processing errors */
 
     /* Items filled by check_arguments() */
 

--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -864,8 +864,8 @@ main(int argc, char **argv)
     g_thread_pool_free(pool, FALSE, TRUE);
 
     // if there were any errors, exit nonzero
-    if( user_data.had_errors ) {
-	exit_val = EXIT_FAILURE;
+    if( cmd_options->error_exit_val && user_data.had_errors ) {
+	exit_val = 2;
     }
 
     g_message("Pool finished%s", (user_data.had_errors ? " with errors" : ""));

--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -328,7 +328,7 @@ main(int argc, char **argv)
     struct CmdOptions *cmd_options;
     gboolean ret;
     GError *tmp_err = NULL;
-
+    int exit_val = EXIT_SUCCESS;
 
     // Arguments parsing
     cmd_options = parse_arguments(&argc, &argv, &tmp_err);
@@ -852,6 +852,7 @@ main(int argc, char **argv)
     user_data.deltatargetpackages = NULL;
     user_data.cut_dirs          = cmd_options->cut_dirs;
     user_data.location_prefix   = cmd_options->location_prefix;
+    user_data.had_errors        = 0;
 
     g_debug("Thread pool user data ready");
 
@@ -861,7 +862,13 @@ main(int argc, char **argv)
 
     // Wait until pool is finished
     g_thread_pool_free(pool, FALSE, TRUE);
-    g_message("Pool finished");
+
+    // if there were any errors, exit nonzero
+    if( user_data.had_errors ) {
+	exit_val = EXIT_FAILURE;
+    }
+
+    g_message("Pool finished%s", (user_data.had_errors ? " with errors" : ""));
 
     cr_xml_dump_cleanup();
 
@@ -1347,5 +1354,5 @@ deltaerror:
     cr_package_parser_cleanup();
 
     g_debug("All done");
-    exit(EXIT_SUCCESS);
+    exit(exit_val);
 }

--- a/src/dumper_thread.c
+++ b/src/dumper_thread.c
@@ -79,6 +79,7 @@ write_pkg(long id,
     if (tmp_err) {
         g_critical("Cannot add primary chunk:\n%s\nError: %s",
                    res.primary, tmp_err->message);
+        udata->had_errors = TRUE;
         g_clear_error(&tmp_err);
     }
 
@@ -87,6 +88,7 @@ write_pkg(long id,
         if (tmp_err) {
             g_critical("Cannot add record of %s (%s) to primary db: %s",
                        pkg->name, pkg->pkgId, tmp_err->message);
+            udata->had_errors = TRUE;
             g_clear_error(&tmp_err);
         }
     }
@@ -103,6 +105,7 @@ write_pkg(long id,
     if (tmp_err) {
         g_critical("Cannot add filelists chunk:\n%s\nError: %s",
                    res.filelists, tmp_err->message);
+        udata->had_errors = TRUE;
         g_clear_error(&tmp_err);
     }
 
@@ -111,6 +114,7 @@ write_pkg(long id,
         if (tmp_err) {
             g_critical("Cannot add record of %s (%s) to filelists db: %s",
                        pkg->name, pkg->pkgId, tmp_err->message);
+            udata->had_errors = TRUE;
             g_clear_error(&tmp_err);
         }
     }
@@ -127,6 +131,7 @@ write_pkg(long id,
     if (tmp_err) {
         g_critical("Cannot add other chunk:\n%s\nError: %s",
                    res.other, tmp_err->message);
+        udata->had_errors = TRUE;
         g_clear_error(&tmp_err);
     }
 
@@ -135,6 +140,7 @@ write_pkg(long id,
         if (tmp_err) {
             g_critical("Cannot add record of %s (%s) to other db: %s",
                        pkg->name, pkg->pkgId, tmp_err->message);
+            udata->had_errors = TRUE;
             g_clear_error(&tmp_err);
         }
     }
@@ -416,6 +422,7 @@ cr_dumper_thread(gpointer data, gpointer user_data)
         if (!pkg) {
             g_warning("Cannot read package: %s: %s",
                       task->full_path, tmp_err->message);
+            udata->had_errors = TRUE;
             g_clear_error(&tmp_err);
             goto task_cleanup;
         }
@@ -424,6 +431,7 @@ cr_dumper_thread(gpointer data, gpointer user_data)
         if (tmp_err) {
             g_critical("Cannot dump XML for %s (%s): %s",
                        pkg->name, pkg->pkgId, tmp_err->message);
+            udata->had_errors = TRUE;
             g_clear_error(&tmp_err);
             goto task_cleanup;
         }
@@ -434,6 +442,7 @@ cr_dumper_thread(gpointer data, gpointer user_data)
         if (tmp_err) {
             g_critical("Cannot dump XML for %s (%s): %s",
                        md->name, md->pkgId, tmp_err->message);
+            udata->had_errors = TRUE;
             g_clear_error(&tmp_err);
             goto task_cleanup;
         }
@@ -572,5 +581,3 @@ task_cleanup:
 
     return;
 }
-
-

--- a/src/dumper_thread.h
+++ b/src/dumper_thread.h
@@ -94,6 +94,7 @@ struct UserData {
                                     // in location href path
     gchar *location_prefix;         // Append this prefix into location_href
                                     // during repodata generation
+    gboolean had_errors;            // Any errors encountered?
 };
 
 


### PR DESCRIPTION
Fixes Issue: https://github.com/rpm-software-management/createrepo_c/issues/58

This adds a flag to UserData for the cr_dumper_thread workers to record if theyt encountered an error, so main() can exit nonzero.
