### PR TITLE
Make set_record act like a setter

### DIFF
--- a/src/repomd.c
+++ b/src/repomd.c
@@ -682,6 +682,14 @@ cr_repomd_set_record(cr_Repomd *repomd,
                      cr_RepomdRecord *record)
 {
     if (!repomd || !record) return;
+
+    cr_RepomdRecord *delrec = NULL;
+    // Remove all existing record of the same type
+    while((delrec = cr_repomd_get_record(repomd, record->type)) != NULL) {
+	cr_repomd_detach_record(repomd, delrec);
+	cr_repomd_record_free(delrec);
+    }
+
     repomd->records = g_slist_append(repomd->records, record);
 }
 

--- a/tests/python/tests/test_repomd.py
+++ b/tests/python/tests/test_repomd.py
@@ -99,6 +99,10 @@ class TestCaseRepomd(unittest.TestCase):
 
         self.assertEqual(len(md.records), 1)
 
+        md.set_record(rec)
+
+        self.assertEqual(len(md.records), 1)
+
         md.repoid = None
         md.contenthash = None
 


### PR DESCRIPTION
This will make sure that when set_record is called, all existing
records of the same type are removed.
It makes no sense to have multiple records of the same type,
and it actively breaks libhifs checksum validation.

Signed-off-by: Patrick Uiterwijk puiterwijk@redhat.com
