### PR TITLE
Close BZ2 compressed files on cr_close

### DIFF
--- a/src/compression_wrapper.c
+++ b/src/compression_wrapper.c
@@ -347,6 +347,7 @@ cr_sopen(const char *filename,
     file = g_malloc0(sizeof(CR_FILE));
     file->mode = mode;
     file->type = type;
+    file->INNERFILE = NULL;
 
     switch (type) {
 
@@ -380,6 +381,7 @@ cr_sopen(const char *filename,
 
         case (CR_CW_BZ2_COMPRESSION): { // ------------------------------------
             FILE *f = fopen(filename, mode_str);
+            file->INNERFILE = f;
             int bzerror;
 
             if (!f) {
@@ -404,6 +406,8 @@ cr_sopen(const char *filename,
 
             if (bzerror != BZ_OK) {
                 const char *err_msg;
+
+                fclose(f);
 
                 switch (bzerror) {
                     case BZ_CONFIG_ERROR:
@@ -641,6 +645,8 @@ cr_close(CR_FILE *cr_file, GError **err)
             else
                 BZ2_bzWriteClose(&rc, (BZFILE *) cr_file->FILE,
                                  BZ2_SKIP_FFLUSH, NULL, NULL);
+
+            fclose(cr_file->INNERFILE);
 
             if (rc == BZ_OK) {
                 ret = CRE_OK;

--- a/src/compression_wrapper.h
+++ b/src/compression_wrapper.h
@@ -79,6 +79,7 @@ void cr_contentstat_free(cr_ContentStat *cstat, GError **err);
 typedef struct {
     cr_CompressionType  type;           /*!< Type of compression */
     void                *FILE;          /*!< Pointer to gzFile, BZFILE, ... */
+    void                *INNERFILE;     /*!< Pointer to underlying FILE */
     cr_OpenMode         mode;           /*!< Mode */
     cr_ContentStat      *stat;          /*!< Content stats */
     cr_ChecksumCtx      *checksum_ctx;  /*!< Checksum contenxt */


### PR DESCRIPTION
Per bzip2 documentation: "BZ2_bzReadClose does not call fclose on the underlying file
handle, so you should do that yourself if appropriate.".
This patch adds a INNERFILE element to CR_FILE to keep track of the FILE object so we
can properly close the file on cr_close.

Signed-off-by: Patrick Uiterwijk <puiterwijk@redhat.com>