### PR TITLE
Preserve old metadata when --update is used and nothing has changed.

### DIFF
--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -833,6 +833,7 @@ main(int argc, char **argv)
     user_data.skip_symlinks     = cmd_options->skip_symlinks;
     user_data.repodir_name_len  = strlen(in_dir);
     user_data.package_count     = package_count;
+    user_data.old_used          = 0;
     user_data.skip_stat         = cmd_options->skip_stat;
     user_data.old_metadata      = old_metadata;
     user_data.mutex_pri         = g_mutex_new();
@@ -869,6 +870,16 @@ main(int argc, char **argv)
     }
 
     g_message("Pool finished%s", (user_data.had_errors ? " with errors" : ""));
+
+    g_debug("Package count: %ld old_used: %ld", package_count, user_data.old_used);
+    if (user_data.old_used == package_count && cmd_options->update) {
+        g_debug("All packages were perfect cache hits, not updating repo.");
+        cr_remove_dir(tmp_out_repo, NULL);
+        if (g_strcmp0(lock_dir, tmp_out_repo))
+            // If lock_dir is not same as temporary repo dir then remove it
+            cr_remove_dir(lock_dir, NULL);
+        exit(EXIT_SUCCESS);
+    }
 
     cr_xml_dump_cleanup();
 

--- a/src/dumper_thread.c
+++ b/src/dumper_thread.c
@@ -387,11 +387,13 @@ cr_dumper_thread(gpointer data, gpointer user_data)
 
             if (udata->skip_stat) {
                 old_used = TRUE;
+                udata->old_used++;
             } else if (stat_buf.st_mtime == md->time_file
                        && stat_buf.st_size == md->size_package
                        && !strcmp(udata->checksum_type_str, md->checksum_type))
             {
                 old_used = TRUE;
+                udata->old_used++;
             } else {
                 g_debug("%s metadata are obsolete -> generating new",
                         task->filename);

--- a/src/dumper_thread.h
+++ b/src/dumper_thread.h
@@ -62,6 +62,7 @@ struct UserData {
     const char *checksum_cachedir;  // Dir with cached checksums
     gboolean skip_symlinks;         // Skip symlinks
     long package_count;             // Total number of packages to process
+    long old_used;                  // Total number of packages where we used the old metadata
 
     // Update stuff
     gboolean skip_stat;             // Skip stat() while updating


### PR DESCRIPTION
In the case where createrepo_c has been called with "--update", if the
repodata for every package we find is satisfied from the existing cache,
do not update the metadata files at all.

This means rsync doesn't have to evaluate the files for changes, and in
the case where '--unique-md-filenames --update' is used, it means rsync
won't have to transfer the newly renamed files.  This saves
approximately 8k of bandwidth (and many round trips) per rsync run in
the cases where nothing in the repo has changed, and also reduces the
time during a scheduled batch job where the repo is out of sync.

In the '--unique-md-filenames --update' case, it also means it won't
rename the files (actually representing only a newer generation of the
exact same data) if '--simple-md-filenames' was previously used on the
same repository.

Signed-off-by: Peter Jones <pjones@redhat.com>