### PR TITLE
mergerepo_c: check if nevra is NULL and warn user about src.rpm naming.

### DIFF
--- a/.distributions
+++ b/.distributions
@@ -1,3 +1,0 @@
-el7 el7.cern
-el6 slc6
-el5 slc5

--- a/.distributions
+++ b/.distributions
@@ -1,0 +1,3 @@
+el7 el7.cern
+el6 slc6
+el5 slc5

--- a/src/mergerepo_c.c
+++ b/src/mergerepo_c.c
@@ -635,6 +635,11 @@ koji_stuff_prepare(struct KojiMergedReposStuff **koji_stuff_ptr,
 
             nevra = cr_split_rpm_filename(pkg->rpm_sourcerpm);
 
+            if (!nevra) {
+                g_debug("Srpm name is invalid: %s", pkg->rpm_sourcerpm);
+                continue;
+            }
+
             if (blocked_srpms) {
                 // Check if srpm is blocked
                 blocked = g_hash_table_lookup_extended(blocked_srpms,
@@ -777,6 +782,11 @@ add_package(cr_Package *pkg,
             // in future.
             struct srpm_val *value;
             cr_NEVRA *nevra = cr_split_rpm_filename(pkg->rpm_sourcerpm);
+            if (!nevra) {
+                 g_debug("Package %s has invalid srpm %s", pkg->name,
+                                                           pkg->rpm_sourcerpm);
+                 return 0;
+            }
             value = g_hash_table_lookup(koji_stuff->include_srpms, nevra->name);
             cr_nevra_free(nevra);
             if (!value || g_strcmp0(pkg->rpm_sourcerpm, value->sourcerpm)) {


### PR DESCRIPTION
$ mkdir build
$ cd build
$ cmake -DCMAKE_BUILD_TYPE:STRING=DEBUG .. && make

$ mkdir repo1 repo2
$ cd repo1
$ wget http://linuxsoft.cern.ch/mirror/artifacts.elastic.co/packages/5.x/yum/5.5.0/elasticsearch-5.5.0.rpm
$ rpm -qpi elasticsearch-5.5.0.rpm

V4 RSA/SHA512 Signature, key ID d88e42b4: NOKEY
Name        : elasticsearch
Epoch       : 0
Version     : 5.5.0
Release     : 1
Architecture: noarch
Install Date: (not installed)
Group       : Application/Internet
Size        : 37317197
License     : 2009
Signature   : RSA/SHA512, Sat 01 Jul 2017 02:14:20 AM CEST, Key ID d27d666cd88e42b4
Source RPM  : elasticsearch-5.5.0-1-src.rpm
Build Date  : Sat 01 Jul 2017 01:20:44 AM CEST
Build Host  : packer-virtualbox-iso-1497797016
Relocations : /usr
Packager    : Elasticsearch
Vendor      : Elasticsearch
URL         : https://www.elastic.co/
Summary     : Elasticsearch is a distributed RESTful search engine built for the cloud. Reference documentation can be found at https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html and the 'Elasticsearch: The Definitive Guide' book can be found at https://www.elastic.co/guide/en/elasticsearch/guide/current/index.html
Description :
Elasticsearch subproject :distribution:rpm

(Note: "Malformed" source rpm elasticsearch-5.5.0-1-src.rpm)

$ cd ../repo2
$ http://mirror.centos.org/centos-7/7/updates/x86_64/Packages/389-ds-base-1.3.5.10-12.el7_3.x86_64.rpm
$ cd ..
$ ./src/createrepo_c repo1/
$ ./src/createrepo_c repo2/
$ ./src/mergerepo_c --koji -a x86_64 --repo=repo1/ --repo=repo2/ 
C_CREATEREPOLIB: Warning: Invalid arch 0-1-src
Segmentation fault (core dumped)

Please review the patch.