### PR TITLE
Correctly identify Requires(missingok) dependencies as legacy Recommends

### DIFF
--- a/src/parsehdr.c
+++ b/src/parsehdr.c
@@ -33,6 +33,7 @@
 
 #ifdef ENABLE_LEGACY_WEAKDEPS
 #define RPMSENSE_STRONG (1 << 27)
+#define RPMSENSE_MISSINGOK (1 << 19)
 #endif
 
 typedef enum DepType_e {
@@ -436,6 +437,12 @@ cr_package_from_header(Header hdr,
                         pkg->obsoletes = g_slist_prepend(pkg->obsoletes, dependency);
                         break;
                     case DEP_REQUIRES:
+#ifdef ENABLE_LEGACY_WEAKDEPS
+                        if ( num_flags & RPMSENSE_MISSINGOK ) {
+                            pkg->recommends = g_slist_prepend(pkg->recommends, dependency);
+                            break;
+                        }
+#endif
                         dependency->pre = pre;
 
                         // XXX: libc.so filtering ////////////////////////////


### PR DESCRIPTION
Prior to RPM 4.12, RPM supported declaring `Recommends` using a hint on the `Requires` tag. The `Requires(missingok)` form was not broadly used, but historically in Mageia and Mandriva, `Suggests` aliased to this at build-time.