### PR TITLE
Enable support for processing legacy tags by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,8 +69,8 @@ ELSE (RPM_PATH)
     message("Using system RPM: ${RPMDB_LIBRARY}")
 ENDIF (RPM_PATH)
 
-# SuSE legacy weak deps support
-OPTION (ENABLE_LEGACY_WEAKDEPS "Enable legacy SUSE weakdeps support?" OFF)
+# SuSE/Mageia/Mandriva legacy weak deps support
+OPTION (ENABLE_LEGACY_WEAKDEPS "Enable legacy SUSE/Mageia/Mandriva weakdeps support?" ON)
 IF (ENABLE_LEGACY_WEAKDEPS)
     ADD_DEFINITIONS("-DENABLE_LEGACY_WEAKDEPS=1")
 ENDIF (ENABLE_LEGACY_WEAKDEPS)

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ By default, cmake should set up things to build for Python 2, but you can do a b
 
 ### ``-DENABLE_LEGACY_WEAKDEPS=ON``
 
-Enable old SUSE weaktags (Default: OFF)
+Enable legacy SUSE/Mageia/Mandriva weakdeps support (Default: ON)
 
 ### ``-DENABLE_THREADED_XZ_ENCODER=ON``
 


### PR DESCRIPTION
At this point, we now have support for a legacy tag that has always existed in RPM (with `Requires(missingok)` support) and there's no good reason to have this disabled by default anymore, as it doesn't introduce extra dependencies of any kind, since the definitions are internal to `createrepo_c` anyway.