### PR TITLE
Fix "CR_DELTA_RPM_SUPPORT redefined" warnings

### DIFF
--- a/src/deltarpms.h.in
+++ b/src/deltarpms.h.in
@@ -35,7 +35,9 @@ extern "C" {
  *  @{
  */
 
+#ifndef CR_DELTA_RPM_SUPPORT
 #cmakedefine CR_DELTA_RPM_SUPPORT
+#endif
 #define CR_DEFAULT_MAX_DELTA_RPM_SIZE   100000000
 
 typedef struct {


### PR DESCRIPTION
If you build createrepo_c with deltarpm support enabled, you get a ton of warnings about "CR_DELTA_RPM_SUPPORT redefined"