### PR TITLE
Fix missing packages in mergerepo_c in case multiple VR exists for single pkg in repo.

### DIFF
--- a/src/mergerepo_c.c
+++ b/src/mergerepo_c.c
@@ -471,7 +471,7 @@ new_merged_metadata_hashtable()
 {
     GHashTable *hashtable = g_hash_table_new_full(g_str_hash,
                                                   g_str_equal,
-                                                  NULL,
+                                                  g_free,
                                                   free_merged_values);
     return hashtable;
 }
@@ -824,7 +824,7 @@ add_package(cr_Package *pkg,
             repopath_with_protocol = prepend_protocol(repopath);
             pkg->location_base = cr_safe_string_chunk_insert(pkg->chunk, repopath_with_protocol);
         }
-        g_hash_table_insert (merged, (gpointer) pkg->name, (gpointer) list);
+        g_hash_table_insert (merged, (gpointer) g_strdup(pkg->name), (gpointer) list);
         return 1;
     }
 


### PR DESCRIPTION
Originally, the `pkg->name` was used as a key for `merged` GHashTable, but this `pkg->name` is freed later if the newer package is found in the same repository: https://github.com/hanzz/createrepo_c/blob/bf9a7e25363e010b50b076cad3505207a757c7d1/src/mergerepo_c.c#L887 . The g_hash_table_lookup then returned NULL.

This PR fixes it by creating copy of `pkg->name` as a key for `merged` GHashTable and frees it on this hash table destruction.