### PR TITLE
Add option to create repodata reproducibly

### DIFF
--- a/doc/createrepo_c.8
+++ b/doc/createrepo_c.8
@@ -117,6 +117,11 @@ Tags to describe the repository itself.
 .SS \-\-revision REVISION
 .sp
 User\-specified revision for this repository.
+.SS \-\-set-timestamp-to-revision
+.sp
+Set timestamp field in metatada to value given with \-\-revision. This require
+\-\-revision being a timestamp formated in "date +%s" format. This option also
+clamp created files modification time to the same value.
 .SS \-\-read\-pkgs\-list READ_PKGS_LIST
 .sp
 Output the paths to the pkgs actually read useful with \-\-update.

--- a/src/cmd_parser.h
+++ b/src/cmd_parser.h
@@ -66,6 +66,8 @@ struct CmdOptions {
     char **content_tags;        /*!< tags for the content in the repository */
     char **repo_tags;           /*!< tags to describe the repo_tagsitory itself */
     char *revision;             /*!< user-specified revision */
+    gboolean set_timestamp_to_revision; /*!< use --revision instead of current
+                                             time for timestamps */
     char *read_pkgs_list;       /*!< output the paths to pkgs actually read */
     gint workers;               /*!< number of threads to spawn */
     gboolean xz_compression;    /*!< use xz for repodata compression */

--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -1410,6 +1410,21 @@ deltaerror:
         cr_repomd_record_rename_file(prestodelta_rec, NULL);
     }
 
+    if (cmd_options->set_timestamp_to_revision) {
+        // validated already in cmd_parser.c:check_arguments
+        gint64 revision = strtoll(cmd_options->revision, NULL, 0);
+        cr_repomd_record_set_timestamp(pri_xml_rec, revision);
+        cr_repomd_record_set_timestamp(fil_xml_rec, revision);
+        cr_repomd_record_set_timestamp(oth_xml_rec, revision);
+        cr_repomd_record_set_timestamp(pri_db_rec, revision);
+        cr_repomd_record_set_timestamp(fil_db_rec, revision);
+        cr_repomd_record_set_timestamp(oth_db_rec, revision);
+        cr_repomd_record_set_timestamp(groupfile_rec, revision);
+        cr_repomd_record_set_timestamp(compressed_groupfile_rec, revision);
+        cr_repomd_record_set_timestamp(updateinfo_rec, revision);
+        cr_repomd_record_set_timestamp(prestodelta_rec, revision);
+    }
+
     // Gen xml
     cr_repomd_set_record(repomd_obj, pri_xml_rec);
     cr_repomd_set_record(repomd_obj, fil_xml_rec);

--- a/src/python/repomdrecord-py.c
+++ b/src/python/repomdrecord-py.c
@@ -225,6 +225,30 @@ rename_file(_RepomdRecordObject *self, G_GNUC_UNUSED void *nothing)
     Py_RETURN_NONE;
 }
 
+PyDoc_STRVAR(set_timestamp__doc__,
+"set_timestamp(timestamp) -> None\n\n"
+"Set timestamp to specific value and adjust file modification time."
+"This is needed to reproduce exact metadata as one produced in the "
+"past from the same package(s).");
+
+static PyObject *
+set_timestamp(_RepomdRecordObject *self, PyObject *args)
+{
+    int timestamp;
+
+    if (!PyArg_ParseTuple(args, "i:timestamp", &timestamp))
+        return NULL;
+
+    if (check_RepomdRecordStatus(self))
+        return NULL;
+
+    if (check_RepomdRecordStatus(self))
+        return NULL;
+
+    cr_repomd_record_set_timestamp(self->record, timestamp);
+    Py_RETURN_NONE;
+}
+
 PyDoc_STRVAR(load_contentstat__doc__,
 "load_contentstat(contentstat) -> None\n\n"
 "Load some content statistics from the ContentStat object. "
@@ -258,6 +282,8 @@ static struct PyMethodDef repomdrecord_methods[] = {
         compress_and_fill__doc__},
     {"rename_file", (PyCFunction)rename_file, METH_NOARGS,
         rename_file__doc__},
+    {"set_timestamp", (PyCFunction)set_timestamp, METH_VARARGS,
+        set_timestamp__doc__},
     {"load_contentstat", (PyCFunction)load_contentstat, METH_VARARGS,
         load_contentstat__doc__},
     {NULL} /* sentinel */

--- a/src/repomd.c
+++ b/src/repomd.c
@@ -21,6 +21,8 @@
 #include <errno.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <sys/types.h>
+#include <utime.h>
 #include <time.h>
 #include <zlib.h>
 #include <assert.h>
@@ -655,6 +657,19 @@ cr_repomd_record_rename_file(cr_RepomdRecord *md, GError **err)
     int retval = rename_file(&(md->location_real), &(md->location_href),
                              checksum, md, err);
     return retval;
+}
+
+void
+cr_repomd_record_set_timestamp(cr_RepomdRecord *record,
+                               gint64 timestamp)
+{
+    struct utimbuf times = { timestamp, timestamp };
+
+    if (!record)
+        return;
+    record->timestamp = timestamp;
+    // intentionally ignore error
+    utime(record->location_real, &times);
 }
 
 void

--- a/src/repomd.h
+++ b/src/repomd.h
@@ -175,6 +175,12 @@ int cr_repomd_record_compress_and_fill(cr_RepomdRecord *record,
  */
 int cr_repomd_record_rename_file(cr_RepomdRecord *record, GError **err);
 
+/** Set timestamp of the file. Needed to reproduce bit-by-bit identical metadata.
+ * @param record                cr_RepomdRecord of file to be renamed
+ * @param timestamp             timestamp in number of seconds since 1970-01-01
+ */
+void cr_repomd_record_set_timestamp(cr_RepomdRecord *record, gint64 timestamp);
+
 /** Load the open stats (checksum_open, checksum_open_type and size_open)
  * from the cr_ContentStat object.
  * @param record                cr_RepomdRecord


### PR DESCRIPTION
Add `createrepo_c --set-timestamp-to-revision`, that set timestamps to the value given with `--revision` option. This way, executing `createrepo_c --revision xxx --set-timestamp-to-revision` twice on the same packages produce bit-by-bit identical results.

This is needed to [reproducibly build](https://reproducible-builds.org/) installation image. See also discussion on similar PR to createrepo, which lead to this specific option: https://github.com/rpm-software-management/createrepo/pull/9

Is there any place where test for `createrepo_c` call as a whole would fit? Since most of the logic is in `main()` (which have `exit()` at the end), it isn't suitable for unit tests...