### PR TITLE
Fix setup of logging (log domains) (RhBug:1645897)

### DIFF
--- a/src/createrepo_shared.c
+++ b/src/createrepo_shared.c
@@ -270,24 +270,17 @@ cr_lock_repo(const gchar *repo_dir,
 void
 cr_setup_logging(gboolean quiet, gboolean verbose)
 {
-    g_log_set_default_handler (cr_log_fn, NULL);
-
     if (quiet) {
         // Quiet mode
-        GLogLevelFlags levels = G_LOG_LEVEL_MESSAGE | G_LOG_LEVEL_INFO |
-                                G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_WARNING;
-        g_log_set_handler(NULL, levels, cr_null_log_fn, NULL);
-        g_log_set_handler("C_CREATEREPOLIB", levels, cr_null_log_fn, NULL);
+        GLogLevelFlags hidden_levels = G_LOG_LEVEL_MESSAGE | G_LOG_LEVEL_INFO |
+                                       G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_WARNING;
+        g_log_set_default_handler (cr_log_fn, GINT_TO_POINTER(hidden_levels));
     } else if (verbose) {
         // Verbose mode
-        GLogLevelFlags levels = G_LOG_LEVEL_MESSAGE | G_LOG_LEVEL_INFO |
-                                G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_WARNING;
-        g_log_set_handler(NULL, levels, cr_log_fn, NULL);
-        g_log_set_handler("C_CREATEREPOLIB", levels, cr_log_fn, NULL);
+        g_log_set_default_handler (cr_log_fn, GINT_TO_POINTER(0));
     } else {
         // Standard mode
-        GLogLevelFlags levels = G_LOG_LEVEL_DEBUG;
-        g_log_set_handler(NULL, levels, cr_null_log_fn, NULL);
-        g_log_set_handler("C_CREATEREPOLIB", levels, cr_null_log_fn, NULL);
+        GLogLevelFlags hidden_levels = G_LOG_LEVEL_DEBUG;
+        g_log_set_default_handler (cr_log_fn, GINT_TO_POINTER(hidden_levels));
     }
 }

--- a/src/misc.c
+++ b/src/misc.c
@@ -912,8 +912,11 @@ void
 cr_log_fn(const gchar *log_domain,
           GLogLevelFlags log_level,
           const gchar *message,
-          G_GNUC_UNUSED gpointer user_data)
+          gpointer user_data)
 {
+    gint hidden_log_levels = GPOINTER_TO_INT(user_data);
+    if (log_level & hidden_log_levels)
+        return;
     switch(log_level) {
         case G_LOG_LEVEL_ERROR:
             if (log_domain) g_printerr("%s: ", log_domain);


### PR DESCRIPTION
New debug messages were added into GLib library. These messages come
from the "GLib" log domain and were not hidden in the standard and
quiet mode of the application.
This fix hides log messages regardless on source log domain.