### PR TITLE
Add zchunk support to modifyrepo_c as well as for mergerepo_c and createrepo_c for extra metadata

### DIFF
--- a/src/cmd_parser.c
+++ b/src/cmd_parser.c
@@ -564,7 +564,7 @@ check_arguments(struct CmdOptions *options,
     }
 
     // Zchunk options
-    if(options->zck_dict_dir && !options->zck_compression) {
+    if (options->zck_dict_dir && !options->zck_compression) {
         g_set_error(err, ERR_DOMAIN, CRE_BADARG,
                     "Cannot use --zck-dict-dir without setting --zck");
         return FALSE;

--- a/src/compression_wrapper.c
+++ b/src/compression_wrapper.c
@@ -880,7 +880,7 @@ cr_close(CR_FILE *cr_file, GError **err)
             zckCtx *zck = (zckCtx *) cr_file->FILE;
             ret = CRE_OK;
             if (cr_file->mode == CR_CW_MODE_WRITE) {
-                if(!zck_end_chunk(zck)) {
+                if(zck_end_chunk(zck) < 0) {
                     ret = CRE_ZCK;
                     g_set_error(err, ERR_DOMAIN, CRE_ZCK,
                         "Unable to end final chunk: %s", zck_get_error(zck));

--- a/src/compression_wrapper.c
+++ b/src/compression_wrapper.c
@@ -296,18 +296,18 @@ cr_ChecksumType
 cr_cktype_from_zck(zckCtx *zck, GError **err)
 {
     int cktype = zck_get_full_hash_type(zck);
-    if(cktype < 0) {
+    if (cktype < 0) {
         g_set_error(err, ERR_DOMAIN, CRE_ZCK,
                     "Unable to read hash from zchunk file");
         return CR_CHECKSUM_UNKNOWN;
     }
-    if(cktype == ZCK_HASH_SHA1)
+    if (cktype == ZCK_HASH_SHA1)
         return CR_CHECKSUM_SHA1;
-    else if(cktype == ZCK_HASH_SHA256)
+    else if (cktype == ZCK_HASH_SHA256)
         return CR_CHECKSUM_SHA256;
     else {
         const char *ckname = zck_hash_name_from_type(cktype);
-        if(ckname == NULL)
+        if (ckname == NULL)
             ckname = "Unknown";
         g_set_error(err, ERR_DOMAIN, CRE_ZCK,
                     "Unknown zchunk checksum type: %s", ckname);
@@ -600,7 +600,7 @@ cr_sopen(const char *filename,
             file->FILE = (void *) zck_create();
             zckCtx *zck = file->FILE;
             if (mode == CR_CW_MODE_WRITE) {
-                if(!file->FILE || !zck_init_write(zck, fd) ||
+                if (!file->FILE || !zck_init_write(zck, fd) ||
                    !zck_set_ioption(zck, ZCK_MANUAL_CHUNK, 1)) {
                     zck_set_log_fd(STDOUT_FILENO);
                     g_set_error(err, ERR_DOMAIN, CRE_IO, "%s",
@@ -654,10 +654,10 @@ cr_sopen(const char *filename,
 
 #ifdef WITH_ZCHUNK
         /* Fill zchunk header_stat with header information */
-        if(mode == CR_CW_MODE_READ && type == CR_CW_ZCK_COMPRESSION) {
+        if (mode == CR_CW_MODE_READ && type == CR_CW_ZCK_COMPRESSION) {
             zckCtx *zck = (zckCtx *)file->FILE;
             cr_ChecksumType cktype = cr_cktype_from_zck(zck, err);
-            if(cktype == CR_CHECKSUM_UNKNOWN) {
+            if (cktype == CR_CHECKSUM_UNKNOWN) {
                 /* Error is already set in cr_cktype_from_zck */
                 g_free(file);
                 return NULL;
@@ -665,7 +665,7 @@ cr_sopen(const char *filename,
             file->stat->hdr_checksum_type = cktype;
             file->stat->hdr_checksum = zck_get_header_digest(zck);
             file->stat->hdr_size = zck_get_header_length(zck);
-            if(*err != NULL || file->stat->hdr_checksum == NULL ||
+            if (*err != NULL || file->stat->hdr_checksum == NULL ||
                file->stat->hdr_size < 0) {
                 g_free(file);
                 return NULL;
@@ -685,7 +685,7 @@ cr_set_dict(CR_FILE *cr_file, const void *dict, unsigned int len, GError **err)
     int ret = CRE_OK;
     assert(!err || *err == NULL);
 
-    if(len == 0)
+    if (len == 0)
         return CRE_OK;
 
     switch (cr_file->type) {
@@ -694,7 +694,7 @@ cr_set_dict(CR_FILE *cr_file, const void *dict, unsigned int len, GError **err)
 #ifdef WITH_ZCHUNK
             zckCtx *zck = (zckCtx *)cr_file->FILE;
             size_t wlen = (size_t)len;
-            if(!zck_set_soption(zck, ZCK_COMP_DICT, dict, wlen)) {
+            if (!zck_set_soption(zck, ZCK_COMP_DICT, dict, wlen)) {
                 ret = CRE_ERROR;
                 g_set_error(err, ERR_DOMAIN, CRE_ZCK,
                             "Error setting dict");
@@ -815,7 +815,7 @@ cr_close(CR_FILE *cr_file, GError **err)
 
                     rc = lzma_code(stream, LZMA_FINISH);
 
-                    if(rc != LZMA_OK && rc != LZMA_STREAM_END) {
+                    if (rc != LZMA_OK && rc != LZMA_STREAM_END) {
                         // Error while coding
                         const char *err_msg;
 
@@ -860,7 +860,7 @@ cr_close(CR_FILE *cr_file, GError **err)
                         break;
                     }
 
-                    if(rc == LZMA_STREAM_END) {
+                    if (rc == LZMA_STREAM_END) {
                         // Everything all right
                         ret = CRE_OK;
                         break;
@@ -880,7 +880,7 @@ cr_close(CR_FILE *cr_file, GError **err)
             zckCtx *zck = (zckCtx *) cr_file->FILE;
             ret = CRE_OK;
             if (cr_file->mode == CR_CW_MODE_WRITE) {
-                if(zck_end_chunk(zck) < 0) {
+                if (zck_end_chunk(zck) < 0) {
                     ret = CRE_ZCK;
                     g_set_error(err, ERR_DOMAIN, CRE_ZCK,
                         "Unable to end final chunk: %s", zck_get_error(zck));
@@ -892,15 +892,15 @@ cr_close(CR_FILE *cr_file, GError **err)
                         "Unable to close zchunk file: %s", zck_get_error(zck));
             }
             cr_ChecksumType cktype = cr_cktype_from_zck(zck, err);
-            if(cktype == CR_CHECKSUM_UNKNOWN) {
+            if (cktype == CR_CHECKSUM_UNKNOWN) {
                 /* Error is already set in cr_cktype_from_zck */
                 break;
             }
-            if(cr_file->stat) {
+            if (cr_file->stat) {
                 cr_file->stat->hdr_checksum_type = cktype;
                 cr_file->stat->hdr_checksum = zck_get_header_digest(zck);
                 cr_file->stat->hdr_size = zck_get_header_length(zck);
-                if((err && *err) || cr_file->stat->hdr_checksum == NULL ||
+                if ((err && *err) || cr_file->stat->hdr_checksum == NULL ||
                    cr_file->stat->hdr_size < 0) {
                     ret = CRE_ZCK;
                     g_set_error(err, ERR_DOMAIN, CRE_ZCK,
@@ -1121,7 +1121,7 @@ cr_read(CR_FILE *cr_file, void *buffer, unsigned int len, GError **err)
 #ifdef WITH_ZCHUNK
             zckCtx *zck = (zckCtx *) cr_file->FILE;
             ssize_t rb = zck_read(zck, buffer, len);
-            if(rb < 0) {
+            if (rb < 0) {
                 ret = CR_CW_ERR;
                 g_set_error(err, ERR_DOMAIN, CRE_ZCK, "ZCK: Unable to read: %s",
                             zck_get_error(zck));
@@ -1307,7 +1307,7 @@ cr_write(CR_FILE *cr_file, const void *buffer, unsigned int len, GError **err)
 #ifdef WITH_ZCHUNK
             zckCtx *zck = (zckCtx *) cr_file->FILE;
             ssize_t wb = zck_write(zck, buffer, len);
-            if(wb < 0) {
+            if (wb < 0) {
                 ret = CR_CW_ERR;
                 g_set_error(err, ERR_DOMAIN, CRE_ZCK,
                             "ZCK: Unable to write: %s", zck_get_error(zck));
@@ -1403,7 +1403,7 @@ cr_end_chunk(CR_FILE *cr_file, GError **err)
 #ifdef WITH_ZCHUNK
             zckCtx *zck = (zckCtx *) cr_file->FILE;
             ssize_t wb = zck_end_chunk(zck);
-            if(wb < 0) {
+            if (wb < 0) {
                 g_set_error(err, ERR_DOMAIN, CRE_ZCK,
                             "Error ending chunk: %s",
                             zck_get_error(zck));
@@ -1454,7 +1454,7 @@ cr_set_autochunk(CR_FILE *cr_file, gboolean auto_chunk, GError **err)
         case (CR_CW_ZCK_COMPRESSION): { // ------------------------------------
 #ifdef WITH_ZCHUNK
             zckCtx *zck = (zckCtx *) cr_file->FILE;
-            if(!zck_set_ioption(zck, ZCK_MANUAL_CHUNK, !auto_chunk)) {
+            if (!zck_set_ioption(zck, ZCK_MANUAL_CHUNK, !auto_chunk)) {
                 g_set_error(err, ERR_DOMAIN, CRE_ZCK,
                             "Error setting auto_chunk: %s",
                             zck_get_error(zck));

--- a/src/compression_wrapper.h
+++ b/src/compression_wrapper.h
@@ -182,6 +182,14 @@ int cr_puts(CR_FILE *cr_file, const char *str, GError **err);
  */
 int cr_end_chunk(CR_FILE *cr_file, GError **err);
 
+/** Set zchunk auto-chunk algorithm.  Must be done before first byte is written
+ * @param cr_file       CR_FILE pointer
+ * @param auto_chunk    Whether auto-chunking should be enabled
+ * @param err           GError **
+ * @return              CRE_OK or CR_CW_ERR
+ */
+int cr_set_autochunk(CR_FILE *cr_file, gboolean auto_chunk, GError **err);
+
 /** Writes a formatted string into the cr_file.
  * @param err           GError **
  * @param cr_file       CR_FILE pointer

--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -837,28 +837,28 @@ main(int argc, char **argv)
     gchar *fil_dict_file = NULL;
     gchar *oth_dict_file = NULL;
 
-    if(cmd_options->zck_dict_dir) {
+    if (cmd_options->zck_dict_dir) {
         pri_dict_file = cr_get_dict_file(cmd_options->zck_dict_dir,
                                          "primary.xml");
         fil_dict_file = cr_get_dict_file(cmd_options->zck_dict_dir,
                                          "filelists.xml");
         oth_dict_file = cr_get_dict_file(cmd_options->zck_dict_dir,
                                          "other.xml");
-        if(pri_dict_file && !g_file_get_contents(pri_dict_file, &pri_dict,
+        if (pri_dict_file && !g_file_get_contents(pri_dict_file, &pri_dict,
                                                  &pri_dict_size, &tmp_err)) {
             g_critical("Error reading zchunk primary dict %s: %s",
                        pri_dict_file, tmp_err->message);
             g_clear_error(&tmp_err);
             exit(EXIT_FAILURE);
         }
-        if(fil_dict_file && !g_file_get_contents(fil_dict_file, &fil_dict,
+        if (fil_dict_file && !g_file_get_contents(fil_dict_file, &fil_dict,
                                                  &fil_dict_size, &tmp_err)) {
             g_critical("Error reading zchunk filelists dict %s: %s",
                        fil_dict_file, tmp_err->message);
             g_clear_error(&tmp_err);
             exit(EXIT_FAILURE);
         }
-        if(oth_dict_file && !g_file_get_contents(oth_dict_file, &oth_dict,
+        if (oth_dict_file && !g_file_get_contents(oth_dict_file, &oth_dict,
                                                  &oth_dict_size, &tmp_err)) {
             g_critical("Error reading zchunk other dict %s: %s",
                        oth_dict_file, tmp_err->message);
@@ -866,7 +866,7 @@ main(int argc, char **argv)
             exit(EXIT_FAILURE);
         }
     }
-    if(cmd_options->zck_compression) {
+    if (cmd_options->zck_compression) {
         g_debug("Creating .xml.zck files");
 
         pri_zck_filename = g_strconcat(tmp_out_repo, "/primary.xml.zck", NULL);
@@ -1013,7 +1013,7 @@ main(int argc, char **argv)
     g_thread_pool_free(pool, FALSE, TRUE);
 
     // if there were any errors, exit nonzero
-    if( cmd_options->error_exit_val && user_data.had_errors ) {
+    if ( cmd_options->error_exit_val && user_data.had_errors ) {
 	exit_val = 2;
     }
 
@@ -1253,7 +1253,7 @@ main(int argc, char **argv)
     }
 
     // Zchunk
-    if(cmd_options->zck_compression) {
+    if (cmd_options->zck_compression) {
         // Prepare repomd records
         pri_zck_rec = cr_repomd_record_new("primary_zck", pri_zck_filename);
         fil_zck_rec = cr_repomd_record_new("filelists_zck", fil_zck_filename);
@@ -1318,7 +1318,7 @@ main(int argc, char **argv)
                 exit(EXIT_FAILURE);
             }
             /* Only create updateinfo_zck if updateinfo isn't already zchunk */
-            if(com_type != CR_CW_ZCK_COMPRESSION) {
+            if (com_type != CR_CW_ZCK_COMPRESSION) {
                 updateinfo_zck_rec = cr_repomd_record_new("updateinfo_zck", updateinfo);
                 cr_repomd_record_compress_and_fill(updateinfo_rec,
                                       updateinfo_zck_rec,
@@ -1409,7 +1409,7 @@ main(int argc, char **argv)
             g_clear_error(&tmp_err);
             goto deltaerror;
         }
-        if(cmd_options->zck_compression && prestodelta_compression != CR_CW_ZCK_COMPRESSION) {
+        if (cmd_options->zck_compression && prestodelta_compression != CR_CW_ZCK_COMPRESSION) {
             filename = g_strconcat("prestodelta.xml",
                                    cr_compression_suffix(CR_CW_ZCK_COMPRESSION),
                                    NULL);
@@ -1455,7 +1455,7 @@ main(int argc, char **argv)
         prestodelta_rec = cr_repomd_record_new("prestodelta", prestodelta_xml_filename);
         cr_repomd_record_load_contentstat(prestodelta_rec, prestodelta_stat);
         cr_repomd_record_fill(prestodelta_rec, cmd_options->repomd_checksum_type, NULL);
-        if(prestodelta_zck_stat) {
+        if (prestodelta_zck_stat) {
             prestodelta_zck_rec = cr_repomd_record_new("prestodelta_zck", prestodelta_zck_filename);
             cr_repomd_record_load_contentstat(prestodelta_zck_rec, prestodelta_zck_stat);
             cr_repomd_record_fill(prestodelta_zck_rec, cmd_options->repomd_checksum_type, NULL);

--- a/src/deltarpms.c
+++ b/src/deltarpms.c
@@ -846,6 +846,7 @@ gen_newpackage_xml_chunk(const char *strnevra,
 gboolean
 cr_deltarpms_generate_prestodelta_file(const gchar *drpmsdir,
                                        cr_XmlFile *f,
+                                       cr_XmlFile *zck_f,
                                        cr_ChecksumType checksum_type,
                                        gint workers,
                                        const gchar *prefix_to_strip,
@@ -917,6 +918,19 @@ cr_deltarpms_generate_prestodelta_file(const gchar *drpmsdir,
 
         chunk = gen_newpackage_xml_chunk(nevra, (GSList *) value);
         cr_xmlfile_add_chunk(f, chunk, NULL);
+
+        /* Write out zchunk file */
+        if(zck_f) {
+            cr_xmlfile_add_chunk(zck_f, chunk, NULL);
+            cr_end_chunk(zck_f->f, &tmp_err);
+            if (tmp_err) {
+                g_free(chunk);
+                g_propagate_prefixed_error(err, tmp_err,
+                    "Cannot create pool for prestodelta file generation: ");
+                ret = FALSE;
+                goto exit;
+            }
+        }
         g_free(chunk);
     }
 

--- a/src/deltarpms.c
+++ b/src/deltarpms.c
@@ -920,7 +920,7 @@ cr_deltarpms_generate_prestodelta_file(const gchar *drpmsdir,
         cr_xmlfile_add_chunk(f, chunk, NULL);
 
         /* Write out zchunk file */
-        if(zck_f) {
+        if (zck_f) {
             cr_xmlfile_add_chunk(zck_f, chunk, NULL);
             cr_end_chunk(zck_f->f, &tmp_err);
             if (tmp_err) {

--- a/src/deltarpms.h.in
+++ b/src/deltarpms.h.in
@@ -112,6 +112,7 @@ cr_deltarpms_scan_targetdir(const char *path,
 gboolean
 cr_deltarpms_generate_prestodelta_file(const gchar *drpmdir,
                                        cr_XmlFile *f,
+                                       cr_XmlFile *zck_f,
                                        cr_ChecksumType checksum_type,
                                        gint workers,
                                        const gchar *prefix_to_strip,

--- a/src/dumper_thread.c
+++ b/src/dumper_thread.c
@@ -79,7 +79,7 @@ write_pkg(long id,
     udata->prev_srpm = udata->cur_srpm;
     udata->cur_srpm = g_strdup(pkg->rpm_sourcerpm);
     gboolean new_pkg = FALSE;
-    if(g_strcmp0(udata->prev_srpm, udata->cur_srpm) != 0)
+    if (g_strcmp0(udata->prev_srpm, udata->cur_srpm) != 0)
         new_pkg = TRUE;
 
     ++udata->id_pri;
@@ -100,8 +100,8 @@ write_pkg(long id,
             g_clear_error(&tmp_err);
         }
     }
-    if(udata->pri_zck) {
-        if(new_pkg) {
+    if (udata->pri_zck) {
+        if (new_pkg) {
             cr_end_chunk(udata->pri_zck->f, &tmp_err);
             if (tmp_err) {
                 g_critical("Unable to end primary zchunk: %s", tmp_err->message);
@@ -144,7 +144,7 @@ write_pkg(long id,
         }
     }
     if (udata->fil_zck) {
-        if(new_pkg) {
+        if (new_pkg) {
             cr_end_chunk(udata->fil_zck->f, &tmp_err);
             if (tmp_err) {
                 g_critical("Unable to end filelists zchunk: %s", tmp_err->message);
@@ -187,7 +187,7 @@ write_pkg(long id,
         }
     }
     if (udata->oth_zck) {
-        if(new_pkg) {
+        if (new_pkg) {
             cr_end_chunk(udata->oth_zck->f, &tmp_err);
             if (tmp_err) {
                 g_critical("Unable to end other zchunk: %s", tmp_err->message);

--- a/src/locate_metadata.c
+++ b/src/locate_metadata.c
@@ -169,7 +169,7 @@ cr_get_remote_metadata(const char *repopath, gboolean ignore_sqlite)
 
     // Create temporary repo in /tmp
     tmp_dir = g_build_filename(g_get_tmp_dir(), TMPDIR_PATTERN, NULL);
-    if(!mkdtemp(tmp_dir)) {
+    if (!mkdtemp(tmp_dir)) {
         g_critical("%s: Cannot create a temporary directory: %s",
                    __func__, g_strerror(errno));
         return ret;

--- a/src/mergerepo_c.c
+++ b/src/mergerepo_c.c
@@ -425,7 +425,7 @@ check_arguments(struct CmdOptions *options)
     }
 
     // Zchunk options
-    if(options->zck_dict_dir && !options->zck_compression) {
+    if (options->zck_dict_dir && !options->zck_compression) {
         g_critical("Cannot use --zck-dict-dir without setting --zck");
         ret = FALSE;
     }
@@ -1173,28 +1173,28 @@ dump_merged_metadata(GHashTable *merged_hashtable,
     gchar *fil_dict_file = NULL;
     gchar *oth_dict_file = NULL;
 
-    if(cmd_options->zck_dict_dir) {
+    if (cmd_options->zck_dict_dir) {
         pri_dict_file = cr_get_dict_file(cmd_options->zck_dict_dir,
                                          "primary.xml");
         fil_dict_file = cr_get_dict_file(cmd_options->zck_dict_dir,
                                          "filelists.xml");
         oth_dict_file = cr_get_dict_file(cmd_options->zck_dict_dir,
                                          "other.xml");
-        if(pri_dict_file && !g_file_get_contents(pri_dict_file, &pri_dict,
+        if (pri_dict_file && !g_file_get_contents(pri_dict_file, &pri_dict,
                                                  &pri_dict_size, &tmp_err)) {
             g_critical("Error reading zchunk primary dict %s: %s",
                        pri_dict_file, tmp_err->message);
             g_clear_error(&tmp_err);
             exit(EXIT_FAILURE);
         }
-        if(fil_dict_file && !g_file_get_contents(fil_dict_file, &fil_dict,
+        if (fil_dict_file && !g_file_get_contents(fil_dict_file, &fil_dict,
                                                  &fil_dict_size, &tmp_err)) {
             g_critical("Error reading zchunk filelists dict %s: %s",
                        fil_dict_file, tmp_err->message);
             g_clear_error(&tmp_err);
             exit(EXIT_FAILURE);
         }
-        if(oth_dict_file && !g_file_get_contents(oth_dict_file, &oth_dict,
+        if (oth_dict_file && !g_file_get_contents(oth_dict_file, &oth_dict,
                                                  &oth_dict_size, &tmp_err)) {
             g_critical("Error reading zchunk other dict %s: %s",
                        oth_dict_file, tmp_err->message);
@@ -1278,7 +1278,7 @@ dump_merged_metadata(GHashTable *merged_hashtable,
     cr_xmlfile_set_num_of_pkgs(fil_f, packages, NULL);
     cr_xmlfile_set_num_of_pkgs(oth_f, packages, NULL);
 
-    if(cmd_options->zck_compression) {
+    if (cmd_options->zck_compression) {
         g_debug("Creating .xml.zck files");
 
         pri_zck_filename = g_strconcat(cmd_options->tmp_out_repo,
@@ -1423,7 +1423,7 @@ dump_merged_metadata(GHashTable *merged_hashtable,
             g_debug("Writing metadata for %s (%s-%s.%s)",
                     pkg->name, pkg->version, pkg->release, pkg->arch);
 
-            if(cmd_options->zck_compression &&
+            if (cmd_options->zck_compression &&
                (!prev_srpm || !pkg->rpm_sourcerpm ||
                 strlen(prev_srpm) != strlen(pkg->rpm_sourcerpm) ||
                 strncmp(pkg->rpm_sourcerpm, prev_srpm, strlen(prev_srpm)) != 0)) {
@@ -1431,7 +1431,7 @@ dump_merged_metadata(GHashTable *merged_hashtable,
                 cr_end_chunk(fil_cr_zck->f, NULL);
                 cr_end_chunk(oth_cr_zck->f, NULL);
                 g_free(prev_srpm);
-                if(pkg->rpm_sourcerpm)
+                if (pkg->rpm_sourcerpm)
                     prev_srpm = g_strdup(pkg->rpm_sourcerpm);
                 else
                     prev_srpm = NULL;
@@ -1439,7 +1439,7 @@ dump_merged_metadata(GHashTable *merged_hashtable,
             cr_xmlfile_add_chunk(pri_f, (const char *) res.primary, NULL);
             cr_xmlfile_add_chunk(fil_f, (const char *) res.filelists, NULL);
             cr_xmlfile_add_chunk(oth_f, (const char *) res.other, NULL);
-            if(cmd_options->zck_compression) {
+            if (cmd_options->zck_compression) {
                 cr_xmlfile_add_chunk(pri_cr_zck, (const char *) res.primary, NULL);
                 cr_xmlfile_add_chunk(fil_cr_zck, (const char *) res.filelists, NULL);
                 cr_xmlfile_add_chunk(oth_cr_zck, (const char *) res.other, NULL);
@@ -1465,7 +1465,7 @@ dump_merged_metadata(GHashTable *merged_hashtable,
     cr_xmlfile_close(pri_f, NULL);
     cr_xmlfile_close(fil_f, NULL);
     cr_xmlfile_close(oth_f, NULL);
-    if(cmd_options->zck_compression) {
+    if (cmd_options->zck_compression) {
         cr_xmlfile_close(pri_cr_zck, NULL);
         cr_xmlfile_close(fil_cr_zck, NULL);
         cr_xmlfile_close(oth_cr_zck, NULL);
@@ -1558,7 +1558,7 @@ dump_merged_metadata(GHashTable *merged_hashtable,
                                            CR_CHECKSUM_SHA256,
                                            cmd_options->groupfile_compression_type,
                                            NULL, NULL);
-        if(cmd_options->zck_compression) {
+        if (cmd_options->zck_compression) {
             groupfile_zck_rec = cr_repomd_record_new("group_zck", groupfile);
             cr_repomd_record_compress_and_fill(groupfile_rec,
                                                groupfile_zck_rec,
@@ -1574,7 +1574,7 @@ dump_merged_metadata(GHashTable *merged_hashtable,
     if (!cmd_options->noupdateinfo) {
         update_info_rec = cr_repomd_record_new("updateinfo", update_info_filename);
         cr_repomd_record_fill(update_info_rec, CR_CHECKSUM_SHA256, NULL);
-        if(cmd_options->zck_compression) {
+        if (cmd_options->zck_compression) {
             update_info_zck_rec = cr_repomd_record_new("updateinfo_zck", update_info_filename);
             cr_repomd_record_compress_and_fill(update_info_rec,
                                                update_info_zck_rec,
@@ -1591,7 +1591,7 @@ dump_merged_metadata(GHashTable *merged_hashtable,
         gchar *pkgorigins_path = g_strconcat(cmd_options->tmp_out_repo, "pkgorigins.gz", NULL);
         pkgorigins_rec = cr_repomd_record_new("origin", pkgorigins_path);
         cr_repomd_record_fill(pkgorigins_rec, CR_CHECKSUM_SHA256, NULL);
-        if(cmd_options->zck_compression) {
+        if (cmd_options->zck_compression) {
             pkgorigins_zck_rec = cr_repomd_record_new("origin_zck", pkgorigins_path);
             cr_repomd_record_compress_and_fill(pkgorigins_rec,
                                                pkgorigins_zck_rec,
@@ -1719,7 +1719,7 @@ dump_merged_metadata(GHashTable *merged_hashtable,
     }
 
     // Zchunk
-    if(cmd_options->zck_compression) {
+    if (cmd_options->zck_compression) {
         // Prepare repomd records
         pri_zck_rec = cr_repomd_record_new("primary_zck", pri_zck_filename);
         fil_zck_rec = cr_repomd_record_new("filelists_zck", fil_zck_filename);

--- a/src/mergerepo_c.c
+++ b/src/mergerepo_c.c
@@ -1554,7 +1554,7 @@ dump_merged_metadata(GHashTable *merged_hashtable,
                                            compressed_groupfile_rec,
                                            CR_CHECKSUM_SHA256,
                                            cmd_options->groupfile_compression_type,
-                                           NULL);
+                                           NULL, NULL);
     }
 
 
@@ -1621,21 +1621,21 @@ dump_merged_metadata(GHashTable *merged_hashtable,
                                              pri_db_c_filename,
                                              cmd_options->db_compression_type,
                                              CR_CHECKSUM_SHA256,
-                                             1, NULL);
+                                             NULL, FALSE, 1, NULL);
         g_thread_pool_push(compress_pool, pri_db_task, NULL);
 
         fil_db_task = cr_compressiontask_new(fil_db_filename,
                                              fil_db_c_filename,
                                              cmd_options->db_compression_type,
                                              CR_CHECKSUM_SHA256,
-                                             1, NULL);
+                                             NULL, FALSE, 1, NULL);
         g_thread_pool_push(compress_pool, fil_db_task, NULL);
 
         oth_db_task = cr_compressiontask_new(oth_db_filename,
                                              oth_db_c_filename,
                                              cmd_options->db_compression_type,
                                              CR_CHECKSUM_SHA256,
-                                             1, NULL);
+                                             NULL, FALSE, 1, NULL);
         g_thread_pool_push(compress_pool, oth_db_task, NULL);
 
         g_thread_pool_free(compress_pool, FALSE, TRUE);

--- a/src/mergerepo_c.c
+++ b/src/mergerepo_c.c
@@ -1509,8 +1509,11 @@ dump_merged_metadata(GHashTable *merged_hashtable,
     cr_RepomdRecord *oth_zck_rec              = NULL;
     cr_RepomdRecord *groupfile_rec            = NULL;
     cr_RepomdRecord *compressed_groupfile_rec = NULL;
+    cr_RepomdRecord *groupfile_zck_rec        = NULL;
     cr_RepomdRecord *update_info_rec          = NULL;
+    cr_RepomdRecord *update_info_zck_rec      = NULL;
     cr_RepomdRecord *pkgorigins_rec           = NULL;
+    cr_RepomdRecord *pkgorigins_zck_rec       = NULL;
 
 
     // XML
@@ -1555,6 +1558,14 @@ dump_merged_metadata(GHashTable *merged_hashtable,
                                            CR_CHECKSUM_SHA256,
                                            cmd_options->groupfile_compression_type,
                                            NULL, NULL);
+        if(cmd_options->zck_compression) {
+            groupfile_zck_rec = cr_repomd_record_new("group_zck", groupfile);
+            cr_repomd_record_compress_and_fill(groupfile_rec,
+                                               groupfile_zck_rec,
+                                               CR_CHECKSUM_SHA256,
+                                               CR_CW_ZCK_COMPRESSION,
+                                               NULL, NULL);
+        }
     }
 
 
@@ -1563,6 +1574,14 @@ dump_merged_metadata(GHashTable *merged_hashtable,
     if (!cmd_options->noupdateinfo) {
         update_info_rec = cr_repomd_record_new("updateinfo", update_info_filename);
         cr_repomd_record_fill(update_info_rec, CR_CHECKSUM_SHA256, NULL);
+        if(cmd_options->zck_compression) {
+            update_info_zck_rec = cr_repomd_record_new("updateinfo_zck", update_info_filename);
+            cr_repomd_record_compress_and_fill(update_info_rec,
+                                               update_info_zck_rec,
+                                               CR_CHECKSUM_SHA256,
+                                               CR_CW_ZCK_COMPRESSION,
+                                               NULL, NULL);
+        }
     }
 
 
@@ -1572,6 +1591,14 @@ dump_merged_metadata(GHashTable *merged_hashtable,
         gchar *pkgorigins_path = g_strconcat(cmd_options->tmp_out_repo, "pkgorigins.gz", NULL);
         pkgorigins_rec = cr_repomd_record_new("origin", pkgorigins_path);
         cr_repomd_record_fill(pkgorigins_rec, CR_CHECKSUM_SHA256, NULL);
+        if(cmd_options->zck_compression) {
+            pkgorigins_zck_rec = cr_repomd_record_new("origin_zck", pkgorigins_path);
+            cr_repomd_record_compress_and_fill(pkgorigins_rec,
+                                               pkgorigins_zck_rec,
+                                               CR_CHECKSUM_SHA256,
+                                               CR_CW_ZCK_COMPRESSION,
+                                               NULL, NULL);
+        }
         g_free(pkgorigins_path);
     }
 
@@ -1752,8 +1779,11 @@ dump_merged_metadata(GHashTable *merged_hashtable,
         cr_repomd_record_rename_file(oth_zck_rec, NULL);
         cr_repomd_record_rename_file(groupfile_rec, NULL);
         cr_repomd_record_rename_file(compressed_groupfile_rec, NULL);
+        cr_repomd_record_rename_file(groupfile_zck_rec, NULL);
         cr_repomd_record_rename_file(update_info_rec, NULL);
+        cr_repomd_record_rename_file(update_info_zck_rec, NULL);
         cr_repomd_record_rename_file(pkgorigins_rec, NULL);
+        cr_repomd_record_rename_file(pkgorigins_zck_rec, NULL);
     }
 
 
@@ -1771,8 +1801,11 @@ dump_merged_metadata(GHashTable *merged_hashtable,
     cr_repomd_set_record(repomd_obj, oth_zck_rec);
     cr_repomd_set_record(repomd_obj, groupfile_rec);
     cr_repomd_set_record(repomd_obj, compressed_groupfile_rec);
+    cr_repomd_set_record(repomd_obj, groupfile_zck_rec);
     cr_repomd_set_record(repomd_obj, update_info_rec);
+    cr_repomd_set_record(repomd_obj, update_info_zck_rec);
     cr_repomd_set_record(repomd_obj, pkgorigins_rec);
+    cr_repomd_set_record(repomd_obj, pkgorigins_zck_rec);
 
     char *repomd_xml = cr_xml_dump_repomd(repomd_obj, NULL);
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -1566,7 +1566,7 @@ cr_get_dict_file(const gchar *dir, const gchar *file)
     assert(dict_file);
 
     snprintf(dict_file, strlen(file) + 7, "%s.zdict", file);
-    gchar *full_path = g_build_path("/", dir, dict_file);
+    gchar *full_path = g_build_path("/", dir, dict_file, NULL);
     assert(full_path);
 
     free(dict_file);

--- a/src/misc.c
+++ b/src/misc.c
@@ -470,10 +470,10 @@ cr_compress_file_with_stat(const char *src,
                               NULL);
     } else if (c_suffix && !g_str_has_suffix(dst, c_suffix)) {
         cr_CompressionType old_type = cr_detect_compression(src, &tmp_err);
-        if(tmp_err) {
+        if (tmp_err) {
             g_debug("%s: Unable to detect compression type of %s", __func__, src);
             g_clear_error(&tmp_err);
-        } else if(old_type != CR_CW_NO_COMPRESSION) {
+        } else if (old_type != CR_CW_NO_COMPRESSION) {
             _cleanup_free_ gchar *tmp_file = g_strndup(dst, strlen(dst) - strlen(cr_compression_suffix(old_type)));
             *in_dst = g_strconcat(tmp_file,
                                   c_suffix,
@@ -485,7 +485,7 @@ cr_compress_file_with_stat(const char *src,
     dst = (gchar *) *in_dst;
 
     int mode = CR_CW_NO_COMPRESSION;
-    if(compression == CR_CW_ZCK_COMPRESSION)
+    if (compression == CR_CW_ZCK_COMPRESSION)
         mode = CR_CW_AUTO_DETECT_COMPRESSION;
 
     orig = cr_open(src,
@@ -500,12 +500,12 @@ cr_compress_file_with_stat(const char *src,
 
     _cleanup_free_ gchar *dict = NULL;
     size_t dict_size = 0;
-    if(compression == CR_CW_ZCK_COMPRESSION && zck_dict_dir) {
+    if (compression == CR_CW_ZCK_COMPRESSION && zck_dict_dir) {
         /* Find zdict */
         _cleanup_free_ gchar *file_basename = NULL;
-        if(dst) {
+        if (dst) {
             _cleanup_free_ gchar *dict_base = NULL;
-            if(g_str_has_suffix(dst, ".zck"))
+            if (g_str_has_suffix(dst, ".zck"))
                 dict_base = g_strndup(dst, strlen(dst)-4);
             else
                 dict_base = g_strdup(dst);
@@ -516,7 +516,7 @@ cr_compress_file_with_stat(const char *src,
         _cleanup_free_ gchar *dict_file = cr_get_dict_file(zck_dict_dir, file_basename);
 
         /* Read dictionary from file */
-        if(dict_file && !g_file_get_contents(dict_file, &dict,
+        if (dict_file && !g_file_get_contents(dict_file, &dict,
                                              &dict_size, &tmp_err)) {
             g_set_error(err, ERR_DOMAIN, CRE_IO,
                         "Error reading zchunk dict %s: %s",
@@ -533,13 +533,13 @@ cr_compress_file_with_stat(const char *src,
         ret = CRE_IO;
         goto compress_file_cleanup;
     }
-    if(compression == CR_CW_ZCK_COMPRESSION) {
-        if(dict && cr_set_dict(new, dict, dict_size, &tmp_err) != CRE_OK) {
+    if (compression == CR_CW_ZCK_COMPRESSION) {
+        if (dict && cr_set_dict(new, dict, dict_size, &tmp_err) != CRE_OK) {
             ret = tmp_err->code;
             g_propagate_prefixed_error(err, tmp_err, "Unable to set zdict for %s: ", dst);
             goto compress_file_cleanup;
         }
-        if(zck_auto_chunk && cr_set_autochunk(new, TRUE, &tmp_err) != CRE_OK) {
+        if (zck_auto_chunk && cr_set_autochunk(new, TRUE, &tmp_err) != CRE_OK) {
             ret = tmp_err->code;
             g_propagate_prefixed_error(err, tmp_err, "Unable to set auto-chunking for %s: ", dst);
             goto compress_file_cleanup;
@@ -1570,7 +1570,7 @@ cr_get_dict_file(const gchar *dir, const gchar *file)
     assert(full_path);
 
     free(dict_file);
-    if(!g_file_test(full_path, G_FILE_TEST_EXISTS)) {
+    if (!g_file_test(full_path, G_FILE_TEST_EXISTS)) {
         g_warning("%s: Zchunk dict %s doesn't exist", __func__, full_path);
         free(full_path);
         return NULL;

--- a/src/misc.h
+++ b/src/misc.h
@@ -179,7 +179,7 @@ gboolean cr_copy_file(const char *src,
 
 /** Compress file.
  * @param src           source filename
- * @param dst           destination (If dst is dir, filename of src +
+ * @param dst           pointer to destination (If dst is dir, filename of src +
  *                      compression suffix is used.
  *                      If dst is NULL, src + compression suffix is used)
  * @param comtype       type of compression
@@ -190,7 +190,7 @@ gboolean cr_copy_file(const char *src,
  * @return              cr_Error return code
  */
 int cr_compress_file_with_stat(const char *src,
-                               const char *dst,
+                               char **dst,
                                cr_CompressionType comtype,
                                cr_ContentStat *stat,
                                const char *zck_dict_dir,

--- a/src/misc.h
+++ b/src/misc.h
@@ -168,11 +168,14 @@ gboolean cr_copy_file(const char *src,
  *                      compression suffix is used.
  *                      If dst is NULL, src + compression suffix is used)
  * @param COMTYPE       type of compression
+ * @param ZCK_DICT_DIR  Location of zchunk zdicts (if zchunk is enabled)
+ * @param ZCK_AUTO_CHUNK Whether zchunk file should be auto-chunked
  * @param ERR           GError **
  * @return              cr_Error return code
  */
-#define cr_compress_file(SRC, DST, COMTYPE, ERR) \
-                    cr_compress_file_with_stat(SRC, DST, COMTYPE, NULL, ERR)
+#define cr_compress_file(SRC, DST, COMTYPE, ZCK_DICT_DIR, ZCK_AUTO_CHUNK, ERR) \
+                    cr_compress_file_with_stat(SRC, DST, COMTYPE, NULL, ZCK_DICT_DIR, \
+                                               ZCK_AUTO_CHUNK, ERR)
 
 /** Compress file.
  * @param src           source filename
@@ -181,6 +184,8 @@ gboolean cr_copy_file(const char *src,
  *                      If dst is NULL, src + compression suffix is used)
  * @param comtype       type of compression
  * @param stat          pointer to cr_ContentStat or NULL
+ * @param zck_dict_dir  Location of zchunk zdicts (if zchunk is enabled)
+ * @param zck_auto_chunk Whether zchunk file should be auto-chunked
  * @param err           GError **
  * @return              cr_Error return code
  */
@@ -188,6 +193,8 @@ int cr_compress_file_with_stat(const char *src,
                                const char *dst,
                                cr_CompressionType comtype,
                                cr_ContentStat *stat,
+                               const char *zck_dict_dir,
+                               gboolean zck_auto_chunk,
                                GError **err);
 
 /** Decompress file.
@@ -541,7 +548,7 @@ cr_version_string_with_features(void);
  * exists or no dictionary directory is set, this function returns NULL
  *
  * The zchunk dictionary file must be the same as the passed filename with a
- * ".dict" extension
+ * ".zdict" extension
  *
  * @param dir           Zchunk dictionary directory
  * @param file          File being zchunked

--- a/src/modifyrepo_c.c
+++ b/src/modifyrepo_c.c
@@ -176,7 +176,7 @@ check_arguments(RawCmdOptions *options, GError **err)
     }
 
     // Zchunk options
-    if(options->zck_dict_dir && !options->zck) {
+    if (options->zck_dict_dir && !options->zck) {
         g_set_error(err, ERR_DOMAIN, CRE_ERROR,
                     "Cannot use --zck-dict-dir without setting --zck");
         return FALSE;

--- a/src/modifyrepo_shared.c
+++ b/src/modifyrepo_shared.c
@@ -90,7 +90,8 @@ write_file(gchar *repopath, cr_ModifyRepoTask *task,
         g_debug("Using already existing file: %s", dst_fn);
     } else {
         // Check if the file already exist
-        if (g_file_test(dst_fn, G_FILE_TEST_EXISTS)) {
+        if (g_file_test(dst_fn, G_FILE_TEST_EXISTS) &&
+            g_str_has_suffix(dst_fn, cr_compression_suffix(compress_type))) {
             g_warning("Destination file \"%s\" already exists and will be "
                       "overwritten", dst_fn);
         }
@@ -99,7 +100,7 @@ write_file(gchar *repopath, cr_ModifyRepoTask *task,
         g_debug("%s: Copy & compress operation %s -> %s",
                  __func__, src_fn, dst_fn);
 
-        if (cr_compress_file(src_fn, dst_fn, compress_type,
+        if (cr_compress_file(src_fn, &dst_fn, compress_type,
                              task->zck_dict_dir, TRUE, err) != CRE_OK) {
             g_debug("%s: Copy & compress operation failed", __func__);
             return NULL;

--- a/src/modifyrepo_shared.c
+++ b/src/modifyrepo_shared.c
@@ -248,7 +248,7 @@ cr_modifyrepo(GSList *modifyrepotasks, gchar *repopath, GError **err)
             compress_type = task->compress_type;
 
         dst_fn = write_file(repopath, task, compress_type, err);
-        if(dst_fn == NULL) {
+        if (dst_fn == NULL) {
             cr_repomd_free(repomd);
             g_free(repomd_path);
             return FALSE;
@@ -256,10 +256,10 @@ cr_modifyrepo(GSList *modifyrepotasks, gchar *repopath, GError **err)
         
         task->repopath = cr_safe_string_chunk_insert_null(task->chunk, dst_fn);
 #ifdef WITH_ZCHUNK
-        if(task->zck) {
+        if (task->zck) {
             free(dst_fn);
             dst_fn = write_file(repopath, task, CR_CW_ZCK_COMPRESSION, err);
-            if(dst_fn == NULL) {
+            if (dst_fn == NULL) {
                 cr_repomd_free(repomd);
                 g_free(repomd_path);
                 return FALSE;
@@ -295,7 +295,7 @@ cr_modifyrepo(GSList *modifyrepotasks, gchar *repopath, GError **err)
             repomdrecords_uniquefn = g_slist_prepend(repomdrecords_uniquefn, rec);
         repomdrecordfilltasks = g_slist_prepend(repomdrecordfilltasks,
                                                 filltask);
-        if(task->zck) {
+        if (task->zck) {
             _cleanup_free_ gchar *type = g_strconcat(task->type, "_zck", NULL);
             rec = cr_repomd_record_new(type, task->zck_repopath);
             filltask = cr_repomdrecordfilltask_new(rec, task->checksum_type, NULL);
@@ -332,7 +332,7 @@ cr_modifyrepo(GSList *modifyrepotasks, gchar *repopath, GError **err)
                     __func__, task->type);
             recordstoremove = g_slist_prepend(recordstoremove, rec);
             cr_repomd_detach_record(repomd, rec);
-            if(task->zck) {
+            if (task->zck) {
                 _cleanup_free_ gchar *type = g_strconcat(task->type, "_zck", NULL);
                 cr_RepomdRecord *rec = cr_repomd_get_record(repomd, type);
                 if (rec) {

--- a/src/modifyrepo_shared.h
+++ b/src/modifyrepo_shared.h
@@ -47,9 +47,12 @@ typedef struct {
     gboolean unique_md_filenames;
     cr_ChecksumType checksum_type;
     gchar *new_name;
+    gboolean zck;
+    gchar *zck_dict_dir;
 
     // Internal use
     gchar *repopath;
+    gchar *zck_repopath;
     gchar *dst_fn;
     GStringChunk *chunk;
 

--- a/src/python/misc-py.c
+++ b/src/python/misc-py.c
@@ -49,7 +49,7 @@ py_compress_file_with_stat(G_GNUC_UNUSED PyObject *self, PyObject *args)
             return NULL;
     }
 
-    cr_compress_file_with_stat(src, dst, type, contentstat, &tmp_err);
+    cr_compress_file_with_stat(src, dst, type, contentstat, NULL, FALSE, &tmp_err);
     if (tmp_err) {
         nice_exception(&tmp_err, NULL);
         return NULL;

--- a/src/python/misc-py.c
+++ b/src/python/misc-py.c
@@ -49,7 +49,7 @@ py_compress_file_with_stat(G_GNUC_UNUSED PyObject *self, PyObject *args)
             return NULL;
     }
 
-    cr_compress_file_with_stat(src, dst, type, contentstat, NULL, FALSE, &tmp_err);
+    cr_compress_file_with_stat(src, &dst, type, contentstat, NULL, FALSE, &tmp_err);
     if (tmp_err) {
         nice_exception(&tmp_err, NULL);
         return NULL;

--- a/src/python/repomdrecord-py.c
+++ b/src/python/repomdrecord-py.c
@@ -182,13 +182,15 @@ compress_and_fill(_RepomdRecordObject *self, PyObject *args)
 {
     int checksum_type, compression_type;
     PyObject *compressed_repomdrecord;
+    gchar *zck_dict_dir = NULL;
     GError *err = NULL;
 
-    if (!PyArg_ParseTuple(args, "O!ii:compress_and_fill",
+    if (!PyArg_ParseTuple(args, "O!ii|s:compress_and_fill",
                           &RepomdRecord_Type,
                           &compressed_repomdrecord,
                           &checksum_type,
-                          &compression_type))
+                          &compression_type,
+                          &zck_dict_dir))
         return NULL;
 
     if (check_RepomdRecordStatus(self))
@@ -198,6 +200,7 @@ compress_and_fill(_RepomdRecordObject *self, PyObject *args)
                                        RepomdRecord_FromPyObject(compressed_repomdrecord),
                                        checksum_type,
                                        compression_type,
+                                       zck_dict_dir,
                                        &err);
     if (err) {
         nice_exception(&err, NULL);

--- a/src/repomd.c
+++ b/src/repomd.c
@@ -110,10 +110,10 @@ cr_repomd_record_copy(const cr_RepomdRecord *orig)
     rec->size_open   = orig->size_open;
     rec->size_header = orig->size_header;
     rec->db_ver      = orig->db_ver;
-    if(orig->checksum_header)
+    if (orig->checksum_header)
         rec->checksum_header      = cr_safe_string_chunk_insert(rec->chunk,
                                                     orig->checksum_header);
-    if(orig->checksum_header_type)
+    if (orig->checksum_header_type)
         rec->checksum_header_type = cr_safe_string_chunk_insert(rec->chunk,
                                                     orig->checksum_header_type);
 
@@ -185,7 +185,7 @@ cr_get_compressed_content_stat(const char *filename,
 
     contentStat* result = g_malloc0(sizeof(contentStat));
     if (result) {
-        if(cwfile->stat) {
+        if (cwfile->stat) {
             result->hdr_checksum = cwfile->stat->hdr_checksum;
             result->hdr_checksum_type = cwfile->stat->hdr_checksum_type;
             result->hdr_size = cwfile->stat->hdr_size;
@@ -286,7 +286,7 @@ cr_repomd_record_fill(cr_RepomdRecord *md,
             md->checksum_open = g_string_chunk_insert(md->chunk, open_stat->checksum);
             if (md->size_open == G_GINT64_CONSTANT(-1))
                 md->size_open = open_stat->size;
-            if(open_stat->hdr_checksum != NULL) {
+            if (open_stat->hdr_checksum != NULL) {
                 const char *hdr_checksum_str = cr_checksum_name_str(open_stat->hdr_checksum_type);
 
                 md->checksum_header_type = g_string_chunk_insert(md->chunk, hdr_checksum_str);
@@ -402,7 +402,7 @@ cr_repomd_record_compress_and_fill(cr_RepomdRecord *record,
     // Compress file + get size of non compressed file
 
     int mode = CR_CW_NO_COMPRESSION;
-    if(record_compression == CR_CW_ZCK_COMPRESSION)
+    if (record_compression == CR_CW_ZCK_COMPRESSION)
         mode = CR_CW_AUTO_DETECT_COMPRESSION;
 
     cw_plain = cr_open(path,
@@ -417,18 +417,18 @@ cr_repomd_record_compress_and_fill(cr_RepomdRecord *record,
 
     _cleanup_free_ gchar *dict = NULL;
     size_t dict_size = 0;
-    if(record_compression == CR_CW_ZCK_COMPRESSION && zck_dict_dir) {
+    if (record_compression == CR_CW_ZCK_COMPRESSION && zck_dict_dir) {
         /* Find zdict */
         _cleanup_free_ gchar *file_basename = NULL;
         _cleanup_free_ gchar *dict_base = NULL;
-        if(g_str_has_suffix(cpath, ".zck"))
+        if (g_str_has_suffix(cpath, ".zck"))
             dict_base = g_strndup(cpath, strlen(cpath)-4);
         else
             dict_base = g_strdup(cpath);
         file_basename = g_path_get_basename(dict_base); 
         _cleanup_free_ gchar *dict_file = cr_get_dict_file(zck_dict_dir, file_basename);
         /* Read dictionary from file */
-        if(dict_file && !g_file_get_contents(dict_file, &dict,
+        if (dict_file && !g_file_get_contents(dict_file, &dict,
                                              &dict_size, &tmp_err)) {
             ret = tmp_err->code;
             g_propagate_prefixed_error(err, tmp_err, "Error reading zchunk dict %s:", dict_file);
@@ -448,13 +448,13 @@ cr_repomd_record_compress_and_fill(cr_RepomdRecord *record,
         return ret;
     }
 
-    if(record_compression == CR_CW_ZCK_COMPRESSION) {
-        if(dict && cr_set_dict(cw_compressed, dict, dict_size, &tmp_err) != CRE_OK) {
+    if (record_compression == CR_CW_ZCK_COMPRESSION) {
+        if (dict && cr_set_dict(cw_compressed, dict, dict_size, &tmp_err) != CRE_OK) {
             ret = tmp_err->code;
             g_propagate_prefixed_error(err, tmp_err, "Unable to set zdict for %s: ", cpath);
             return ret;
         }
-        if(cr_set_autochunk(cw_compressed, TRUE, &tmp_err) != CRE_OK) {
+        if (cr_set_autochunk(cw_compressed, TRUE, &tmp_err) != CRE_OK) {
             ret = tmp_err->code;
             g_propagate_prefixed_error(err, tmp_err, "Unable to set auto-chunking for %s: ", cpath);
             return ret;
@@ -529,7 +529,7 @@ cr_repomd_record_compress_and_fill(cr_RepomdRecord *record,
 
     cgf_size = cgf_stat.st_size;
     cgf_time = cgf_stat.st_mtime;
-    if(out_stat->hdr_checksum) {
+    if (out_stat->hdr_checksum) {
         cgf_hdrsize = out_stat->hdr_size;
         hdr_checksum_str = cr_checksum_name_str(out_stat->hdr_checksum_type);
         hdrchecksum = out_stat->hdr_checksum;
@@ -552,7 +552,7 @@ cr_repomd_record_compress_and_fill(cr_RepomdRecord *record,
     crecord->checksum_type = g_string_chunk_insert(crecord->chunk, checksum_str);
     crecord->checksum_open = g_string_chunk_insert(record->chunk, checksum);
     crecord->checksum_open_type = g_string_chunk_insert(record->chunk, checksum_str);
-    if(hdr_checksum_str) {
+    if (hdr_checksum_str) {
         crecord->checksum_header = g_string_chunk_insert(crecord->chunk, hdrchecksum);
         crecord->checksum_header_type = g_string_chunk_insert(crecord->chunk, hdr_checksum_str);
     } else {
@@ -798,7 +798,7 @@ cr_repomd_set_record(cr_Repomd *repomd,
 
     cr_RepomdRecord *delrec = NULL;
     // Remove all existing record of the same type
-    while((delrec = cr_repomd_get_record(repomd, record->type)) != NULL) {
+    while ((delrec = cr_repomd_get_record(repomd, record->type)) != NULL) {
 	cr_repomd_detach_record(repomd, delrec);
 	cr_repomd_record_free(delrec);
     }

--- a/src/repomd.h
+++ b/src/repomd.h
@@ -159,6 +159,7 @@ int cr_repomd_record_fill(cr_RepomdRecord *record,
  * @param compressed_record     empty cr_RepomdRecord object that will by filled
  * @param checksum_type         type of checksums
  * @param compression           type of compression
+ * @param zck_dict_dir          Location of zchunk dictionaries (NULL if unused)
  * @param err                   GError **
  * @return                      cr_Error code
  */
@@ -166,6 +167,7 @@ int cr_repomd_record_compress_and_fill(cr_RepomdRecord *record,
                                        cr_RepomdRecord *compressed_record,
                                        cr_ChecksumType checksum_type,
                                        cr_CompressionType compression,
+                                       const char *zck_dict_dir,
                                        GError **err);
 
 /** Add a hash as prefix to the filename.

--- a/src/sqliterepo_c.c
+++ b/src/sqliterepo_c.c
@@ -391,21 +391,21 @@ compress_sqlite_dbs(const gchar *tmp_out_repo,
                                          pri_db_name,
                                          compression_type,
                                          checksum_type,
-                                         1, NULL);
+                                         NULL, FALSE, 1, NULL);
     g_thread_pool_push(compress_pool, pri_db_task, NULL);
 
     fil_db_task = cr_compressiontask_new(fil_db_filename,
                                          fil_db_name,
                                          compression_type,
                                          checksum_type,
-                                         1, NULL);
+                                         NULL, FALSE, 1, NULL);
     g_thread_pool_push(compress_pool, fil_db_task, NULL);
 
     oth_db_task = cr_compressiontask_new(oth_db_filename,
                                          oth_db_name,
                                          compression_type,
                                          checksum_type,
-                                         1, NULL);
+                                         NULL, FALSE, 1, NULL);
     g_thread_pool_push(compress_pool, oth_db_task, NULL);
 
     // Wait till all tasks are complete and free the thread pool

--- a/src/threads.c
+++ b/src/threads.c
@@ -32,6 +32,8 @@ cr_compressiontask_new(const char *src,
                        const char *dst,
                        cr_CompressionType compression_type,
                        cr_ChecksumType checksum_type,
+                       const char *zck_dict_dir,
+                       gboolean zck_auto_chunk,
                        int delsrc,
                        GError **err)
 {
@@ -58,6 +60,9 @@ cr_compressiontask_new(const char *src,
     task->dst    = g_strdup(dst);
     task->type   = compression_type;
     task->stat   = stat;
+    if(zck_dict_dir != NULL)
+        task->zck_dict_dir = g_strdup(zck_dict_dir);
+    task->zck_auto_chunk = zck_auto_chunk;
     task->delsrc = delsrc;
 
     return task;
@@ -76,6 +81,8 @@ cr_compressiontask_free(cr_CompressionTask *task, GError **err)
     cr_contentstat_free(task->stat, err);
     if (task->err)
         g_error_free(task->err);
+    if (task->zck_dict_dir)
+        g_free(task->zck_dict_dir);
     g_free(task);
 }
 
@@ -96,6 +103,8 @@ cr_compressing_thread(gpointer data, G_GNUC_UNUSED gpointer user_data)
                                task->dst,
                                task->type,
                                task->stat,
+                               task->zck_dict_dir,
+                               task->zck_auto_chunk,
                                &tmp_err);
 
     if (tmp_err) {

--- a/src/threads.c
+++ b/src/threads.c
@@ -100,7 +100,7 @@ cr_compressing_thread(gpointer data, G_GNUC_UNUSED gpointer user_data)
                                 NULL);
 
     cr_compress_file_with_stat(task->src,
-                               task->dst,
+                               &(task->dst),
                                task->type,
                                task->stat,
                                task->zck_dict_dir,

--- a/src/threads.c
+++ b/src/threads.c
@@ -60,7 +60,7 @@ cr_compressiontask_new(const char *src,
     task->dst    = g_strdup(dst);
     task->type   = compression_type;
     task->stat   = stat;
-    if(zck_dict_dir != NULL)
+    if (zck_dict_dir != NULL)
         task->zck_dict_dir = g_strdup(zck_dict_dir);
     task->zck_auto_chunk = zck_auto_chunk;
     task->delsrc = delsrc;

--- a/src/threads.h
+++ b/src/threads.h
@@ -76,6 +76,10 @@ typedef struct {
         Type of compression to use */
     cr_ContentStat *stat; /*!<
         Stats of compressed file or NULL */
+    char *zck_dict_dir; /*!<
+        Location of zchunk dictionaries */
+    gboolean zck_auto_chunk; /*!<
+        Whether zchunk file should be auto-chunked */
     int delsrc; /*!<
         Indicate if delete source file after successful compression. */
     GError *err; /*!<
@@ -106,6 +110,8 @@ cr_compressiontask_new(const char *src,
                        const char *dst,
                        cr_CompressionType compression_type,
                        cr_ChecksumType checksum_type,
+                       const char *zck_dict_dir,
+                       gboolean zck_auto_chunk,
                        int delsrc,
                        GError **err);
 

--- a/tests/test_misc.c
+++ b/tests/test_misc.c
@@ -531,8 +531,8 @@ compressfile_test_text_file(Copyfiletest *copyfiletest,
     GError *tmp_err = NULL;
 
     g_assert(!g_file_test(copyfiletest->dst_file, G_FILE_TEST_EXISTS));
-    ret = cr_compress_file(TEST_TEXT_FILE, copyfiletest->dst_file,
-                           CR_CW_GZ_COMPRESSION, &tmp_err);
+    ret = cr_compress_file(TEST_TEXT_FILE, &(copyfiletest->dst_file),
+                           CR_CW_GZ_COMPRESSION, NULL, FALSE, &tmp_err);
     g_assert(!tmp_err);
     g_assert_cmpint(ret, ==, CRE_OK);
     g_assert(g_file_test(copyfiletest->dst_file, G_FILE_TEST_IS_REGULAR));
@@ -556,8 +556,9 @@ compressfile_with_stat_test_text_file(Copyfiletest *copyfiletest,
     g_assert(!tmp_err);
 
     g_assert(!g_file_test(copyfiletest->dst_file, G_FILE_TEST_EXISTS));
-    ret = cr_compress_file_with_stat(TEST_TEXT_FILE, copyfiletest->dst_file,
-                                     CR_CW_GZ_COMPRESSION, stat, &tmp_err);
+    ret = cr_compress_file_with_stat(TEST_TEXT_FILE, &copyfiletest->dst_file,
+                                     CR_CW_GZ_COMPRESSION, stat, NULL, FALSE,
+                                     &tmp_err);
     g_assert(!tmp_err);
     g_assert_cmpint(ret, ==, CRE_OK);
     g_assert(g_file_test(copyfiletest->dst_file, G_FILE_TEST_IS_REGULAR));


### PR DESCRIPTION
This patch fixes cr_close() so it doesn't error if zck_end_chunk returns a positive number.