### PR TITLE
Find correct nosetests version even when which command is not available.

### DIFF
--- a/tests/python/tests/CMakeLists.txt
+++ b/tests/python/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} -c "import sys; sys.stdout.write('%
 SET(NOSETEST_VERSION_SUFFIX "-${PYTHON_MAJOR_DOT_MINOR_VERSION}")
 message("-- nosetests program is nosetests${NOSETEST_VERSION_SUFFIX}")
 
-execute_process(COMMAND which nosetests${NOSETEST_VERSION_SUFFIX}
+execute_process(COMMAND nosetests${NOSETEST_VERSION_SUFFIX} --help
                 OUTPUT_QUIET ERROR_QUIET
                 RESULT_VARIABLE NOSE_CHECK_RESULT)
 IF (NOT NOSE_CHECK_RESULT STREQUAL "0")


### PR DESCRIPTION
To test on different OS versions, I run builds and tests in containers to which I install the minimal dependencies described in https://github.com/rpm-software-management/createrepo_c/blob/master/README.md. I saw a failure

```
-- Python install dir is /usr/lib64/python3.7/site-packages
-- Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE) 
-- nosetests program is nosetests-3.7
Command 'nosetests-3.7' doesn't exist! Using only 'nosetests' instead
-- Configuring done
[...]
```
and python tests were failing.

But I had python3-nose-1.3.7-21.fc29.noarch installed which brings
```
# rpm -ql python3-nose | grep /usr/bin
/usr/bin/nosetests-3
/usr/bin/nosetests-3.7
```
so defaulting to just `nosetests` was wrong.

The problem is in the `which` command which is not installed in container images by default. Since it is not documented as a dependency and it is not actually needed, let's remove it.