### PR TITLE
The .spec file typically lands under ~/rpmbuild/SPECS/.

### DIFF
--- a/utils/make_rpm.sh
+++ b/utils/make_rpm.sh
@@ -26,8 +26,8 @@ echo "Generating rpm for $GITREV"
 
 echo "Cleaning $BUILD_DIR"
 rm -rf "$BUILD_DIR"
-echo "Removing $RPMBUILD_DIR/$PACKAGE.spec"
-rm -f "$RPMBUILD_DIR/$PACKAGE.spec"
+echo "Removing $RPMBUILD_DIR/SPECS/$PACKAGE.spec"
+rm -f "$RPMBUILD_DIR/SPECS/$PACKAGE.spec"
 
 echo "> Making tarball .."
 "$MY_DIR/make_tarball.sh" "$GITREV"


### PR DESCRIPTION
Addressing
```
Cleaning /root/rpmbuild//BUILD
Removing /root/rpmbuild//createrepo_c.spec
```