### PR TITLE
When authority (host) is present, cr_get_local_metadata would not get path starting with /.

### DIFF
--- a/src/locate_metadata.c
+++ b/src/locate_metadata.c
@@ -290,7 +290,7 @@ cr_locate_metadata(const char *repopath, gboolean ignore_sqlite, GError **err)
         ret = cr_get_remote_metadata(repopath, ignore_sqlite);
     } else {
         // Local metadata
-        if (g_str_has_prefix(repopath, "file://"))
+        if (g_str_has_prefix(repopath, "file:///"))
             repopath += 7;
         ret = cr_get_local_metadata(repopath, ignore_sqlite);
     }


### PR DESCRIPTION
RFC 8089 Appendix B shows that the local file with empty authority has three slashes.

That same example appendix also shows `file:/path/to/file` but the original
code did not support it anyway.