### PR TITLE
Revert "Update logging function for standard mode"

### DIFF
--- a/src/createrepo_shared.c
+++ b/src/createrepo_shared.c
@@ -280,7 +280,7 @@ cr_setup_logging(gboolean quiet, gboolean verbose)
         g_log_set_default_handler (cr_log_fn, GINT_TO_POINTER(0));
     } else {
         // Standard mode
-        GLogLevelFlags hidden_levels = G_LOG_LEVEL_MESSAGE;
+        GLogLevelFlags hidden_levels = G_LOG_LEVEL_DEBUG;
         g_log_set_default_handler (cr_log_fn, GINT_TO_POINTER(hidden_levels));
     }
 }


### PR DESCRIPTION
This reverts commit 4c2f4f48f259c19219d4d640884c5df7a7d4fc5e.

This re-fixes mockchain's ability to use createrepo_c. It was originally fixed by #108