### PR TITLE
Make createrepo obsolete conditional

### DIFF
--- a/createrepo_c.spec
+++ b/createrepo_c.spec
@@ -61,8 +61,11 @@ Requires: rpm >= 4.9.0
 %if %{with drpm}
 BuildRequires:  drpm-devel >= 0.1.3
 %endif
+
+%if 0%{?fedora} > 30 || 0%{?rhel} > 7
 Obsoletes:      createrepo < 0.11.0
 Provides:       createrepo = %{version}-%{release}
+%endif
 
 %description
 C implementation of Createrepo.


### PR DESCRIPTION
The obsolete should be applied only for Fedora 31+ where createrepo is
going to disappear, and for RHEL8.

The obsolete in EPEL-7 cannot be applied, because it obsoletes the core
package of RHEL7.