### PR TITLE
Prevent race condition when --update & we have duplicate pkgs (RhBug:1696808)

### DIFF
--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -995,6 +995,7 @@ main(int argc, char **argv)
     user_data.id_oth            = 0;
     user_data.buffer            = g_queue_new();
     user_data.mutex_buffer      = g_mutex_new();
+    user_data.mutex_old_md      = g_mutex_new();
     user_data.deltas            = cmd_options->deltas;
     user_data.max_delta_rpm_size= cmd_options->max_delta_rpm_size;
     user_data.mutex_deltatargetpackages = g_mutex_new();
@@ -1049,6 +1050,7 @@ main(int argc, char **argv)
 
     g_queue_free(user_data.buffer);
     g_mutex_free(user_data.mutex_buffer);
+    g_mutex_free(user_data.mutex_old_md);
     g_cond_free(user_data.cond_pri);
     g_cond_free(user_data.cond_fil);
     g_cond_free(user_data.cond_oth);

--- a/src/dumper_thread.h
+++ b/src/dumper_thread.h
@@ -71,6 +71,7 @@ struct UserData {
     // Update stuff
     gboolean skip_stat;             // Skip stat() while updating
     cr_Metadata *old_metadata;      // Loaded metadata
+    GMutex *mutex_old_md;           // Mutex for accessing old metadata
 
     // Thread serialization
     GMutex *mutex_pri;              // Mutex for primary metadata


### PR DESCRIPTION
This PR aims to fix possible race condition when we use `--update` option (which loads old metadata but identical pkgs get only one record) and our new repo contains multiple occurrences of one pkg. 
Each occurrence of the one pkg is handled in separate thread and they all want to modify `location_href` and `location_base` of the old loaded single record.

With this change only the first thread gets the old record and every other duplicate thread has to load the package from disk again. This approach should have negligible slow down effect on runs with only a few or none duplicate pkgs, which I assume are much more common.