### PR TITLE
Add --pkgorigins mode

### DIFF
--- a/doc/mergerepo_c.8
+++ b/doc/mergerepo_c.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MERGEREPO_C  "2017-02-23" "" ""
+.TH MERGEREPO_C  "2019-05-03" "" ""
 .SH NAME
 mergerepo_c \- Merge multiple rpm-md format repositories together
 .
@@ -81,6 +81,9 @@ Don\(aqt add a baseurl to packages that don\(aqt have one before.
 .SS \-k \-\-koji
 .sp
 Enable koji mergerepos behaviour.
+.SS \-\-pkgorigins
+.sp
+Enable standard mergerepos behavior while also providing the pkgorigins file for koji.
 .SS \-g \-\-groupfile GROUPFILE
 .sp
 Path to groupfile to include in metadata.

--- a/src/koji.c
+++ b/src/koji.c
@@ -42,10 +42,10 @@ koji_stuff_destroy(struct KojiMergedReposStuff **koji_stuff_ptr)
 
     koji_stuff = *koji_stuff_ptr;
 
-    if (koji_stuff->blocked_srpms)
-        g_hash_table_destroy(koji_stuff->blocked_srpms);
-    g_hash_table_destroy(koji_stuff->include_srpms);
-    g_hash_table_destroy(koji_stuff->seen_rpms);
+    g_clear_pointer (&koji_stuff->blocked_srpms, g_hash_table_destroy);
+    g_clear_pointer (&koji_stuff->include_srpms, g_hash_table_destroy);
+    g_clear_pointer (&koji_stuff->seen_rpms, g_hash_table_destroy);
+
     cr_close(koji_stuff->pkgorigins, NULL);
     g_free(koji_stuff);
 }

--- a/src/koji.h
+++ b/src/koji.h
@@ -80,6 +80,11 @@ struct KojiMergedReposStuff {
     gboolean simple;
 };
 
+/* Limited version of koji_stuff_prepare() that sets up only pkgorigins */
+int
+pkgorigins_prepare(struct KojiMergedReposStuff **koji_stuff_ptr,
+                   const gchar *tmpdir);
+
 int
 koji_stuff_prepare(struct KojiMergedReposStuff **koji_stuff_ptr,
                    struct CmdOptions *cmd_options,

--- a/src/mergerepo_c.c
+++ b/src/mergerepo_c.c
@@ -118,6 +118,10 @@ static GOptionEntry cmd_entries[] =
     { "simple", 0, 0, G_OPTION_ARG_NONE, &(_cmd_options.koji_simple),
        "Enable koji specific simple merge mode where we keep even packages with "
        "identical NEVRAs. Only works with combination with --koji/-k.", NULL},
+    { "pkgorigins", 0, 0, G_OPTION_ARG_NONE, &(_cmd_options.pkgorigins),
+        "Enable standard mergerepos behavior while also providing the "
+        "pkgorigins file for koji.",
+        NULL},
     { "groupfile", 'g', 0, G_OPTION_ARG_FILENAME, &(_cmd_options.groupfile),
       "Path to groupfile to include in metadata.", "GROUPFILE" },
     { "blocked", 'b', 0, G_OPTION_ARG_FILENAME, &(_cmd_options.blocked),
@@ -1359,7 +1363,7 @@ dump_merged_metadata(GHashTable *merged_hashtable,
 
     // Pkgorigins
 
-    if (cmd_options->koji) {
+    if (cmd_options->koji || cmd_options->pkgorigins) {
         gchar *pkgorigins_path = g_strconcat(cmd_options->tmp_out_repo, "pkgorigins.gz", NULL);
         pkgorigins_rec = cr_repomd_record_new("origin", pkgorigins_path);
         cr_repomd_record_fill(pkgorigins_rec, CR_CHECKSUM_SHA256, NULL);
@@ -1876,6 +1880,8 @@ main(int argc, char **argv)
     struct KojiMergedReposStuff *koji_stuff = NULL;
     if (cmd_options->koji)
         koji_stuff_prepare(&koji_stuff, cmd_options, local_repos);
+    else if (cmd_options->pkgorigins)
+        pkgorigins_prepare(&koji_stuff, cmd_options->tmp_out_repo);
 
 
     // Load metadata
@@ -1908,7 +1914,7 @@ main(int argc, char **argv)
 
     // Destroy koji stuff - we have to close pkgorigins file before dump
 
-    if (cmd_options->koji)
+    if (cmd_options->koji || cmd_options->pkgorigins)
         koji_stuff_destroy(&koji_stuff);
 
 

--- a/src/mergerepo_c.h
+++ b/src/mergerepo_c.h
@@ -69,6 +69,7 @@ struct CmdOptions {
     // Koji mergerepos specific options
     gboolean koji;
     gboolean koji_simple;
+    gboolean pkgorigins;
     char *groupfile;
     char *blocked;
 


### PR DESCRIPTION
When handling modules, we want a mode of operation for Koji that
handles the pkgorigins file but does not do any of the other
filtering or blocking that the --koji mode does.

Note: this patch doesn't need to change any code where the
pkgorigins file is actually populated, because it was already
conditionalized merely on the koji_stuff->pkgorigins pointer
being non-NULL, not driven by the cmd_options->koji.

Also includes a small patch to make the `koji_stuff_destroy()`
routine more resilient and handle when it's not fully constructed.