### PR TITLE
 Correct pkg count (RhBug:1596211) and warnings

### DIFF
--- a/doc/createrepo_c.8
+++ b/doc/createrepo_c.8
@@ -134,15 +134,9 @@ Use xz for repodata compression.
 .SS \-\-zck
 .sp
 Generate zchunk files as well as the standard repodata.
-.SS \-\-zck\-primary\-dict ZCK_PRIMARY_DICT
+.SS \-\-zck\-dict\-dir ZCK_DICT_DIR
 .sp
-Compression dictionary to use for zchunk primary file
-.SS \-\-zck\-filelists\-dict ZCK_FILELISTS_DICT
-.sp
-Compression dictionary to use for zchunk filelists file
-.SS \-\-zck\-other\-dict ZCK_OTHER_DICT
-.sp
-Compression dictionary to use for zchunk other file
+Directory containing compression dictionaries for use by zchunk.
 .SS \-\-compress\-type COMPRESSION_TYPE
 .sp
 Which compression type to use.

--- a/src/compression_wrapper.h
+++ b/src/compression_wrapper.h
@@ -190,6 +190,15 @@ int cr_end_chunk(CR_FILE *cr_file, GError **err);
  */
 int cr_set_autochunk(CR_FILE *cr_file, gboolean auto_chunk, GError **err);
 
+/** Get specific zchunks data indentified by index
+ * @param cr_file       CR_FILE pointer
+ * @param zchunk_index  Index of wanted zchunk
+ * @param copy_buf      Output pointer, upon return contains wanted zchunk data
+ * @param err           GError **
+ * @return              Size of data from zchunk indexed by zchunk_index
+ */
+ssize_t cr_get_zchunk_with_index(CR_FILE *f, ssize_t zchunk_index, char **copy_buf, GError **err);
+
 /** Writes a formatted string into the cr_file.
  * @param err           GError **
  * @param cr_file       CR_FILE pointer

--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -592,7 +592,6 @@ main(int argc, char **argv)
 
     // Thread pool - Creation
     struct UserData user_data = {0};
-    g_thread_init(NULL);
     GThreadPool *pool = g_thread_pool_new(cr_dumper_thread,
                                           &user_data,
                                           0,
@@ -1079,21 +1078,12 @@ main(int argc, char **argv)
     user_data.package_count     = 0;
     user_data.skip_stat         = cmd_options->skip_stat;
     user_data.old_metadata      = old_metadata;
-    user_data.mutex_pri         = g_mutex_new();
-    user_data.mutex_fil         = g_mutex_new();
-    user_data.mutex_oth         = g_mutex_new();
-    user_data.cond_pri          = g_cond_new();
-    user_data.cond_fil          = g_cond_new();
-    user_data.cond_oth          = g_cond_new();
     user_data.id_pri            = 0;
     user_data.id_fil            = 0;
     user_data.id_oth            = 0;
     user_data.buffer            = g_queue_new();
-    user_data.mutex_buffer      = g_mutex_new();
-    user_data.mutex_old_md      = g_mutex_new();
     user_data.deltas            = cmd_options->deltas;
     user_data.max_delta_rpm_size= cmd_options->max_delta_rpm_size;
-    user_data.mutex_deltatargetpackages = g_mutex_new();
     user_data.deltatargetpackages = NULL;
     user_data.cut_dirs          = cmd_options->cut_dirs;
     user_data.location_prefix   = cmd_options->location_prefix;
@@ -1241,15 +1231,6 @@ main(int argc, char **argv)
     }
 
     g_queue_free(user_data.buffer);
-    g_mutex_free(user_data.mutex_buffer);
-    g_mutex_free(user_data.mutex_old_md);
-    g_cond_free(user_data.cond_pri);
-    g_cond_free(user_data.cond_fil);
-    g_cond_free(user_data.cond_oth);
-    g_mutex_free(user_data.mutex_pri);
-    g_mutex_free(user_data.mutex_fil);
-    g_mutex_free(user_data.mutex_oth);
-    g_mutex_free(user_data.mutex_deltatargetpackages);
 
     // Create repomd records for each file
     g_debug("Generating repomd.xml");

--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -562,6 +562,9 @@ main(int argc, char **argv)
         exit(EXIT_FAILURE);
     }
 
+    // Set exit_value pointer used in cleanup handlers
+    cr_set_global_exit_value(&exit_val);
+
     // Setup cleanup handlers
     if (!cr_set_cleanup_handler(lock_dir, tmp_out_repo, &tmp_err)) {
         g_printerr("%s\n", tmp_err->message);

--- a/src/createrepo_shared.c
+++ b/src/createrepo_shared.c
@@ -28,6 +28,7 @@
 #include "misc.h"
 #include "cleanup.h"
 
+int *global_exit_status = NULL;  // pointer to exit_value used in failure_exit_cleanup
 
 char *global_lock_dir     = NULL;  // Path to .repodata/ dir that is used as a lock
 char *global_tmp_out_repo = NULL;  // Path to temporary repodata directory,
@@ -40,13 +41,11 @@ char *global_tmp_out_repo = NULL;  // Path to temporary repodata directory,
  * for other createrepo[_c] processes.
  * This functions acts only if exit status != EXIST_SUCCESS.
  *
- * @param exit_status       Status
- * @param data              User data (unused)
  */
 static void
-failure_exit_cleanup(int exit_status, G_GNUC_UNUSED void *data)
+failure_exit_cleanup()
 {
-    if (exit_status != EXIT_SUCCESS) {
+    if (global_exit_status && *global_exit_status != EXIT_SUCCESS) {
         if (global_lock_dir) {
             g_debug("Removing %s", global_lock_dir);
             cr_remove_dir(global_lock_dir, NULL);
@@ -67,6 +66,12 @@ sigint_catcher(int sig)
 {
     g_message("%s catched: Terminating...", strsignal(sig));
     exit(1);
+}
+
+void
+cr_set_global_exit_value(int *exit_val)
+{
+    global_exit_status = exit_val;
 }
 
 gboolean

--- a/src/createrepo_shared.h
+++ b/src/createrepo_shared.h
@@ -40,13 +40,12 @@ extern "C" {
 
 /**
  * This function does:
- * 1) Sets atexit cleanup function that removes temporary directories
- * 2) Sets a signal handler for signals that lead to process temination.
- *    (List obtained from the "man 7 signal")
- *    Signals that are ignored (SIGCHILD) or lead just to stop (SIGSTOP, ...)
- *    don't get this handler - these signals do not terminate the process!
- *    This handler assures that the cleanup function that is hooked on exit
- *    gets called.
+ * Sets a signal handler for signals that lead to process temination.
+ * (List obtained from the "man 7 signal")
+ * Signals that are ignored (SIGCHILD) or lead just to stop (SIGSTOP, ...)
+ * don't get this handler - these signals do not terminate the process!
+ * This handler assures that the cleanup function that is hooked on exit
+ * gets called.
  *
  * @param lock_dir      Dir that serves as lock (".repodata/")
  * @param tmp_out_repo  Dir that is really used for repodata generation
@@ -120,6 +119,13 @@ cr_unset_cleanup_handler(GError **err);
  */
 void
 cr_setup_logging(gboolean quiet, gboolean verbose);
+
+/**
+ * Set global pointer to exit value that is used in function set by atexit
+ * @param exit_val          Pointer to exit_value int
+ */
+void
+cr_set_global_exit_value(int *exit_val);
 
 /** @} */
 

--- a/src/dumper_thread.c
+++ b/src/dumper_thread.c
@@ -75,6 +75,7 @@ write_pkg(long id,
     while (udata->id_pri != id)
         g_cond_wait (udata->cond_pri, udata->mutex_pri);
 
+    udata->package_count++;
     g_free(udata->prev_srpm);
     udata->prev_srpm = udata->cur_srpm;
     udata->cur_srpm = g_strdup(pkg->rpm_sourcerpm);
@@ -540,7 +541,7 @@ cr_dumper_thread(gpointer data, gpointer user_data)
 
     if (g_queue_get_length(udata->buffer) < MAX_TASK_BUFFER_LEN
         && udata->id_pri != task->id
-        && udata->package_count > (task->id + 1))
+        && udata->task_count > (task->id + 1))
     {
         // If:
         //  * this isn't our turn

--- a/src/dumper_thread.h
+++ b/src/dumper_thread.h
@@ -66,7 +66,8 @@ struct UserData {
     cr_ChecksumType checksum_type;  // Constant representing selected checksum
     const char *checksum_cachedir;  // Dir with cached checksums
     gboolean skip_symlinks;         // Skip symlinks
-    long package_count;             // Total number of packages to process
+    long task_count;                // Total number of task to process
+    long package_count;             // Total number of packages processed
 
     // Update stuff
     gboolean skip_stat;             // Skip stat() while updating

--- a/src/dumper_thread.h
+++ b/src/dumper_thread.h
@@ -72,28 +72,28 @@ struct UserData {
     // Update stuff
     gboolean skip_stat;             // Skip stat() while updating
     cr_Metadata *old_metadata;      // Loaded metadata
-    GMutex *mutex_old_md;           // Mutex for accessing old metadata
+    GMutex mutex_old_md;           // Mutex for accessing old metadata
 
     // Thread serialization
-    GMutex *mutex_pri;              // Mutex for primary metadata
-    GMutex *mutex_fil;              // Mutex for filelists metadata
-    GMutex *mutex_oth;              // Mutex for other metadata
-    GCond *cond_pri;                // Condition for primary metadata
-    GCond *cond_fil;                // Condition for filelists metadata
-    GCond *cond_oth;                // Condition for other metadata
+    GMutex mutex_pri;              // Mutex for primary metadata
+    GMutex mutex_fil;              // Mutex for filelists metadata
+    GMutex mutex_oth;              // Mutex for other metadata
+    GCond cond_pri;                // Condition for primary metadata
+    GCond cond_fil;                // Condition for filelists metadata
+    GCond cond_oth;                // Condition for other metadata
     volatile long id_pri;           // ID of task on turn (write primary metadata)
     volatile long id_fil;           // ID of task on turn (write filelists metadata)
     volatile long id_oth;           // ID of task on turn (write other metadata)
 
     // Buffering
     GQueue *buffer;                 // Buffer for done tasks
-    GMutex *mutex_buffer;           // Mutex for accessing the buffer
+    GMutex mutex_buffer;           // Mutex for accessing the buffer
 
     // Delta generation
     gboolean deltas;                // Are deltas enabled?
     gint64 max_delta_rpm_size;      // Max size of an rpm that to run
                                     // deltarpm against
-    GMutex *mutex_deltatargetpackages; // Mutex
+    GMutex mutex_deltatargetpackages; // Mutex
     GSList *deltatargetpackages;    // List of cr_DeltaTargetPackages
 
     // Location href modifiers

--- a/src/mergerepo_c.c
+++ b/src/mergerepo_c.c
@@ -1736,8 +1736,6 @@ main(int argc, char **argv)
 
     g_debug("Version: %s", cr_version_string_with_features());
 
-    g_thread_init(NULL); // Initialize threading
-
     // Prepare out_repo
 
     if (g_file_test(cmd_options->tmp_out_repo, G_FILE_TEST_EXISTS)) {

--- a/src/modifyrepo_c.c
+++ b/src/modifyrepo_c.c
@@ -291,8 +291,6 @@ main(int argc, char **argv)
         exit(EXIT_FAILURE);
     }
 
-    g_thread_init(NULL); // Initialize threading
-
     // Emit debug message with version
 
     g_debug("Version: %s", cr_version_string_with_features());

--- a/src/sqliterepo_c.c
+++ b/src/sqliterepo_c.c
@@ -1017,8 +1017,6 @@ main(int argc, char **argv)
     // Emit debug message with version
     g_debug("Version: %s", cr_version_string_with_features());
 
-    g_thread_init(NULL); // Initialize threading
-
     // Gen the databases
     ret = generate_sqlite_from_xml(argv[1],
                                    options->compression_type,

--- a/src/threads.c
+++ b/src/threads.c
@@ -21,6 +21,7 @@
 #include "threads.h"
 #include "error.h"
 #include "misc.h"
+#include "dumper_thread.h"
 
 #define ERR_DOMAIN      CREATEREPO_C_ERROR
 
@@ -114,6 +115,29 @@ cr_compressing_thread(gpointer data, G_GNUC_UNUSED gpointer user_data)
         // Compression was successful
         if (task->delsrc)
             remove(task->src);
+    }
+}
+
+void
+cr_rewrite_pkg_count_thread(gpointer data, gpointer user_data)
+{
+    cr_CompressionTask *task = data;
+    struct UserData *ud = user_data;
+    GError *tmp_err = NULL;
+
+    assert(task);
+
+    cr_rewrite_header_package_count(task->src,
+                                    task->type,
+                                    ud->package_count,
+                                    ud->task_count,
+                                    task->stat,
+                                    task->zck_dict_dir,
+                                    &tmp_err);
+
+    if (tmp_err) {
+        // Error encountered
+        g_propagate_error(&task->err, tmp_err);
     }
 }
 

--- a/src/threads.h
+++ b/src/threads.h
@@ -156,6 +156,11 @@ cr_repomdrecordfilltask_free(cr_RepomdRecordFillTask *task, GError **err);
 void
 cr_repomd_record_fill_thread(gpointer data, gpointer user_data);
 
+/** Function for GThread Pool.
+ */
+void
+cr_rewrite_pkg_count_thread(gpointer data, gpointer user_data);
+
 /** @} */
 
 #ifdef __cplusplus

--- a/src/xml_file.c
+++ b/src/xml_file.c
@@ -18,8 +18,10 @@
  */
 
 #include <glib.h>
+#include <glib/gstdio.h>
 #include <assert.h>
 #include "xml_file.h"
+#include <errno.h>
 #include "error.h"
 #include "xml_dump.h"
 #include "compression_wrapper.h"
@@ -39,6 +41,9 @@
                                 CR_XML_OTHER_NS"\" packages=\"%d\">\n"
 #define XML_PRESTODELTA_HEADER  XML_HEADER"<prestodelta>\n"
 #define XML_UPDATEINFO_HEADER   XML_HEADER"<updates>\n"
+
+#define XML_MAX_HEADER_SIZE     300
+#define XML_RECOMPRESS_BUFFER_SIZE   8192
 
 #define XML_PRIMARY_FOOTER      "</metadata>"
 #define XML_FILELISTS_FOOTER    "</filelists>"
@@ -316,4 +321,172 @@ cr_xmlfile_close(cr_XmlFile *f, GError **err)
     g_free(f);
 
     return CRE_OK;
+}
+
+static int 
+write_modified_header(int task_count,
+                      int package_count,
+                      cr_XmlFile *cr_file,
+                      gchar *header_buf,
+                      int header_len,
+                      GError **err)
+{
+    GError *tmp_err = NULL;
+    gchar *package_count_string;
+    gchar *task_count_string;
+    int bytes_written = 0;
+    int package_count_string_len = rasprintf(&package_count_string, "packages=\"%i\"", package_count);
+    int task_count_string_len = rasprintf(&task_count_string, "packages=\"%i\"", task_count);
+
+    gchar *pointer_to_pkgs = strstr(header_buf, task_count_string);
+    if (!pointer_to_pkgs){
+        g_free(package_count_string);
+        g_free(task_count_string);
+        return 0;
+    }
+    gchar *pointer_to_pkgs_end = pointer_to_pkgs + task_count_string_len;
+
+    bytes_written += cr_write(cr_file->f, header_buf, pointer_to_pkgs - header_buf, &tmp_err);
+    if (!tmp_err)
+        bytes_written += cr_write(cr_file->f, package_count_string, package_count_string_len, &tmp_err);
+    if (!tmp_err)
+        bytes_written += cr_write(cr_file->f, pointer_to_pkgs_end, header_len - (pointer_to_pkgs_end - header_buf), &tmp_err);
+    if (tmp_err) {
+        g_propagate_prefixed_error(err, tmp_err, "Error encountered while writing header part:");
+        g_free(package_count_string);
+        g_free(task_count_string);
+        return 0;
+    }
+    g_free(package_count_string);
+    g_free(task_count_string);
+    return bytes_written;
+}
+
+void
+cr_rewrite_header_package_count(gchar *original_filename,
+                                cr_CompressionType xml_compression,
+                                int package_count,
+                                int task_count,
+                                cr_ContentStat *file_stat,
+                                gchar *zck_dict_file,
+                                GError **err)
+{
+    GError *tmp_err = NULL;
+    CR_FILE *original_file = cr_open(original_filename, CR_CW_MODE_READ, CR_CW_AUTO_DETECT_COMPRESSION, &tmp_err);
+    if (tmp_err) {
+        g_propagate_prefixed_error(err, tmp_err, "Error encountered while reopening for reading:");
+        return;
+    }
+
+    gchar *tmp_xml_filename = g_strconcat(original_filename, ".tmp", NULL);
+    cr_XmlFile *new_file = cr_xmlfile_sopen_primary(tmp_xml_filename,
+                                                    xml_compression,
+                                                    file_stat,
+                                                    &tmp_err);
+    if (tmp_err) {
+        g_propagate_prefixed_error(err, tmp_err, "Error encountered while opening for writing:");
+        cr_close(original_file, NULL); 
+        g_free(tmp_xml_filename);
+        return;
+    }
+
+    // We want to keep identical zchunk chunk sizes, therefore we copy by chunk
+    if (xml_compression == CR_CW_ZCK_COMPRESSION) {
+        if (zck_dict_file){
+            gchar *zck_dict = NULL;
+            size_t zck_dict_size = 0;
+            g_file_get_contents(zck_dict_file, &zck_dict, &zck_dict_size, &tmp_err);
+            if (!tmp_err)
+                cr_set_dict(new_file->f, zck_dict, zck_dict_size, &tmp_err);
+            if (tmp_err) {
+                g_propagate_prefixed_error(err, tmp_err, "Error encountered setting zck dict:");
+                cr_xmlfile_close(new_file, NULL);
+                cr_close(original_file, NULL); 
+                g_free(tmp_xml_filename);
+                return;
+            }
+        }
+
+        char *copy_buf = NULL;
+        // Chunk with index 0 is dictionary, data (xml metadata and our header) starts at 1 
+        ssize_t zchunk_index = 1;
+        ssize_t len_read = cr_get_zchunk_with_index(original_file, zchunk_index, &copy_buf, &tmp_err);
+        if (!tmp_err)
+            write_modified_header(task_count, package_count, new_file, copy_buf, len_read, &tmp_err);
+        if (tmp_err){
+            g_propagate_prefixed_error(err, tmp_err, "Error encountered while recompressing:");
+            cr_xmlfile_close(new_file, NULL);
+            cr_close(original_file, NULL);
+            g_free(tmp_xml_filename);
+            return;
+        }
+        zchunk_index++;
+        while(len_read){
+            g_free(copy_buf);
+            len_read = cr_get_zchunk_with_index(original_file, zchunk_index, &copy_buf, &tmp_err);
+            if (!tmp_err)
+                cr_write(new_file->f, copy_buf, len_read, &tmp_err);
+            if (!tmp_err)
+                cr_end_chunk(new_file->f, &tmp_err);
+            if (tmp_err) {
+                g_propagate_prefixed_error(err, tmp_err, "Error encountered while recompressing:");
+                cr_xmlfile_close(new_file, NULL);
+                cr_close(original_file, NULL); 
+                g_free(tmp_xml_filename);
+                return;
+            }
+            zchunk_index++;
+        }
+    } else {
+        gchar header_buf[XML_MAX_HEADER_SIZE];
+        int len_read = cr_read(original_file, header_buf, XML_MAX_HEADER_SIZE, &tmp_err);
+        if (!tmp_err)
+            write_modified_header(task_count, package_count, new_file, header_buf, len_read, &tmp_err);
+        if (tmp_err) {
+            g_propagate_prefixed_error(err, tmp_err, "Error encountered while recompressing:");
+            cr_xmlfile_close(new_file, NULL);
+            cr_close(original_file, NULL); 
+            g_free(tmp_xml_filename);
+            return;
+        }
+        //Copy the rest of the file
+        gchar copy_buf[XML_RECOMPRESS_BUFFER_SIZE];
+        while(len_read)
+        {
+            len_read = cr_read(original_file, copy_buf, XML_RECOMPRESS_BUFFER_SIZE, &tmp_err);
+            if (!tmp_err)
+                cr_write(new_file->f, copy_buf, len_read, &tmp_err);
+            if (tmp_err) {
+                g_propagate_prefixed_error(err, tmp_err, "Error encountered while recompressing:");
+                cr_xmlfile_close(new_file, NULL);
+                cr_close(original_file, NULL); 
+                g_free(tmp_xml_filename);
+                return;
+            }
+        }
+    }
+
+    new_file->header = 1;
+    new_file->footer = 1;
+
+    cr_xmlfile_close(new_file, &tmp_err);
+    if (tmp_err) {
+        g_propagate_prefixed_error(err, tmp_err, "Error encountered while writing:");
+        cr_close(original_file, NULL); 
+        g_free(tmp_xml_filename);
+        return;
+    }
+    cr_close(original_file, &tmp_err); 
+    if (tmp_err) {
+        g_propagate_prefixed_error(err, tmp_err, "Error encountered while writing:");
+        g_free(tmp_xml_filename);
+        return;
+    }
+
+    if (g_rename(tmp_xml_filename, original_filename) == -1) {
+        g_propagate_prefixed_error(err, tmp_err, "Error encountered while renaming:");
+        g_free(tmp_xml_filename);
+        return;
+    }
+    g_free(tmp_xml_filename);
 }

--- a/src/xml_file.h
+++ b/src/xml_file.h
@@ -221,6 +221,24 @@ int cr_xmlfile_add_chunk(cr_XmlFile *f, const char *chunk, GError **err);
  */
 int cr_xmlfile_close(cr_XmlFile *f, GError **err);
 
+/** Rewrite package count field in repodata header in xml file.
+ * In order to do this we have to decompress and after the change
+ * compress the whole file again, so entirely new file is created.
+ * @param original_filename     Current file with wrong value in header
+ * @param package_count         Actual package count (desired value in header)
+ * @param task_count            Task count (current value in header)
+ * @param file_stat             cr_ContentStat for stats of the new file, it will be modified
+ * @param zck_dict_file         Optional path to zck dictionary
+ * @param err                   **GError
+ */
+void cr_rewrite_header_package_count(gchar *original_filename,
+                                     cr_CompressionType xml_compression,
+                                     int package_count,
+                                     int task_count,
+                                     cr_ContentStat *file_stat,
+                                     gchar *zck_dict_file,
+                                     GError **err);
+ 
 
 /** @} */
 


### PR DESCRIPTION
First two commits deal with RhBug: 1596211, where createrepo_c was generating repodata with wrong values in package count fileds if there were invalid packages. This happened because createrepo_c actually wrote there the task count (each package has its own task), but if some task failed no metadata for it was generated however it was still counted in the total package count. 

Because we know the actual package count only after all the package tasks have finished and compressed their metadata into repodata files we cannot simply change the package count value. In order to get to it we have decompress affected repodata files, change the value and compress them again. This is a significant performance blow.

The last two commits are dealing with some compiler warnings. 