### PR TITLE
Depend on the appropriate minimum version of libmodulemd

### DIFF
--- a/createrepo_c.spec
+++ b/createrepo_c.spec
@@ -1,3 +1,5 @@
+%global libmodulemd_version 2.3.0
+
 # Bash completion (we need different approach for RHEL-6)
 %if 0%{?rhel} == 6
 %global bash_completion %config%{_sysconfdir}/bash_completion.d/createrepo_c.bash
@@ -58,8 +60,9 @@ BuildRequires:  pkgconfig(zck) >= 0.9.11
 BuildRequires:  zchunk
 %endif
 %if %{with libmodulemd}
-BuildRequires:  pkgconfig(modulemd-2.0) >= 2.3.0
+BuildRequires:  pkgconfig(modulemd-2.0) >= %{libmodulemd_version}
 BuildRequires:  libmodulemd
+Requires:       libmodulemd%{?_isa} >= %{libmodulemd_version}
 %endif
 Requires:       %{name}-libs =  %{version}-%{release}
 %if 0%{?rhel} == 6


### PR DESCRIPTION
Without this, under some circumstances it's not updating libmodulemd on the
system and if it gets 2.2.x or older, createrepo_c fails with undefined
symbol: modulemd_module_index_update_from_custom

Based on commit in Fedora downstream: https://src.fedoraproject.org/rpms/createrepo_c/c/40377017d0fc34d222a56ea1ad07ed63557a7a7d