### PR TITLE
Add explicit initialization of GMutexes and GConds (RhBug:1714666)

### DIFF
--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -1092,6 +1092,16 @@ main(int argc, char **argv)
     user_data.location_prefix   = cmd_options->location_prefix;
     user_data.had_errors        = 0;
 
+    g_mutex_init(&(user_data.mutex_pri));
+    g_mutex_init(&(user_data.mutex_fil));
+    g_mutex_init(&(user_data.mutex_oth));
+    g_cond_init(&(user_data.cond_pri));
+    g_cond_init(&(user_data.cond_fil));
+    g_cond_init(&(user_data.cond_oth));
+    g_mutex_init(&(user_data.mutex_buffer));
+    g_mutex_init(&(user_data.mutex_old_md));
+    g_mutex_init(&(user_data.mutex_deltatargetpackages));
+
     g_debug("Thread pool user data ready");
 
     // Start pool
@@ -1241,6 +1251,15 @@ main(int argc, char **argv)
     }
 
     g_queue_free(user_data.buffer);
+    g_mutex_clear(&(user_data.mutex_pri));
+    g_mutex_clear(&(user_data.mutex_fil));
+    g_mutex_clear(&(user_data.mutex_oth));
+    g_cond_clear(&(user_data.cond_pri));
+    g_cond_clear(&(user_data.cond_fil));
+    g_cond_clear(&(user_data.cond_oth));
+    g_mutex_clear(&(user_data.mutex_buffer));
+    g_mutex_clear(&(user_data.mutex_old_md));
+    g_mutex_clear(&(user_data.mutex_deltatargetpackages));
 
     // Create repomd records for each file
     g_debug("Generating repomd.xml");


### PR DESCRIPTION
GMutexes and GConds require their memory to be initialized to zeros, in createrepo_c.c the user_data struct which contains GMutexes and GConds is initialized to zeros when created. This however was not the case in deltarpms.c which caused createrepo_c to hang if `--deltas` was used.

This PR adds explicit initialization of GMutexes and GConds as it is safer and better adheres to the GLib Threads documentation.

(I didn't do this when I was [originally converting](https://github.com/rpm-software-management/createrepo_c/commit/6355d0f0433344a07f5903c6c126f623fb10e2f6) to the new API because I confused static and automatic allocation while reading the GLib docs)