### PR TITLE
Add missing python metadata to python2/3-createrepo_c (RhBug:1695677)

### DIFF
--- a/createrepo_c.spec
+++ b/createrepo_c.spec
@@ -251,11 +251,13 @@ ln -sr %{buildroot}%{_bindir}/modifyrepo_c %{buildroot}%{_bindir}/modifyrepo
 %if %{with python2}
 %files -n python2-%{name}
 %{python2_sitearch}/%{name}/
+%{python2_sitearch}/%{name}-%{version}-py%{python2_version}.egg-info
 %endif
 
 %if %{with python3}
 %files -n python3-%{name}
 %{python3_sitearch}/%{name}/
+%{python3_sitearch}/%{name}-%{version}-py%{python3_version}.egg-info
 %endif
 
 %changelog

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -88,4 +88,7 @@ IF (SKBUILD)
 ELSE ()
     INSTALL(FILES createrepo_c/__init__.py DESTINATION ${PYTHON_INSTALL_DIR}/createrepo_c)
     INSTALL(TARGETS _createrepo_c LIBRARY DESTINATION ${PYTHON_INSTALL_DIR}/createrepo_c)
+
+    # Version has to be passed as last argument.
+    INSTALL(CODE "EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/utils/setup_for_python_metadata.py install_egg_info --install-dir \$ENV{DESTDIR}/${PYTHON_INSTALL_DIR} ${VERSION})")
 ENDIF ()

--- a/utils/setup_for_python_metadata.py
+++ b/utils/setup_for_python_metadata.py
@@ -1,0 +1,32 @@
+from distutils.core import setup
+import sys
+
+# This is a simple and fragile way of passing the current version
+# from cmake to setup as I assume no one else will use this.
+#
+# This script has to have the version always specified as last argument.
+version = sys.argv.pop()
+
+setup(
+    name='createrepo_c',
+    description='C implementation of createrepo',
+    version=version,
+    license='GPLv2+',
+    author='RPM Software Management',
+    author_email='rpm-ecosystem@lists.rpm.org',
+    url='https://github.com/rpm-software-management',
+    classifiers=[
+        'License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)',
+        'Operating System :: POSIX :: Linux',
+        'Programming Language :: C',
+        'Topic :: System :: Software Distribution',
+        'Topic :: System :: Systems Administration',
+        "Programming Language :: Python :: 2",
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+    ],
+)


### PR DESCRIPTION
In order not to depend on scikit-build I added additional python setup
script (setup_for_python_metadata.py) which uses just setuptools and is
used to generate egg-info metadata during building of packages
python2/3-createrepo_c.

Related to #145