### PR TITLE
Fix --read-pkgs-list to only list actually read packages

### DIFF
--- a/src/dumper_thread.c
+++ b/src/dumper_thread.c
@@ -500,6 +500,12 @@ cr_dumper_thread(gpointer data, gpointer user_data)
             g_clear_error(&tmp_err);
             goto task_cleanup;
         }
+
+        if (udata->output_pkg_list){
+            g_mutex_lock(&(udata->mutex_output_pkg_list));
+            fprintf(udata->output_pkg_list, "%s\n", pkg->location_href);
+            g_mutex_unlock(&(udata->mutex_output_pkg_list));
+        }
     } else {
         // Just gen XML from old loaded metadata
         pkg = md;

--- a/src/dumper_thread.h
+++ b/src/dumper_thread.h
@@ -102,6 +102,9 @@ struct UserData {
     gchar *location_prefix;         // Append this prefix into location_href
                                     // during repodata generation
     gboolean had_errors;            // Any errors encountered?
+
+    FILE *output_pkg_list;          // File where a list of read packages is written
+    GMutex mutex_output_pkg_list;   // Mutex for output_pkg_list file
 };
 
 


### PR DESCRIPTION
As specified in the man page: file created by --read-pkgs-list should contain a list of only actually read packages not all the tasks createrepo_c creates.

This way it also works with --update to create a list of only updated packages.

This addresses root cause of https://github.com/rpm-software-management/createrepo_c/issues/130.