### PR TITLE
Update documentaition: retain-old-md, compatibility, koji simple, merge methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,12 @@ Createrepo_c mimics this behaviour.
 - There are old metadata without checksum in the name too
 - (https://bugzilla.redhat.com/show_bug.cgi?id=836917)
 
+## Mergerepo_c
+### Default merge method
+- Original mergerepo included even packages with the same NVR by default
+- Mergerepo_c can be configured by --method option to specify how repositories should be merged. 
+- Additionally its possible to use --all option to replicate original mergerepo behavior.
+
 ## Modifyrepo_c
 
 Modifyrepo_c is compatible with classical Modifyrepo except some misbehaviour:

--- a/doc/createrepo_c.8
+++ b/doc/createrepo_c.8
@@ -104,7 +104,10 @@ Include the file\(aqs checksum in the metadata filename, helps HTTP caching (def
 Do not include the file\(aqs checksum in the metadata filename.
 .SS \-\-retain\-old\-md NUM
 .sp
-Keep around the latest (by timestamp) N copies of the old repodata.
+Specify NUM to 0 to remove all repodata present in old repomd.xml or any other positive number to keep all old repodata.
+.sp
+Use --compatibility flag to get the behavior of original createrepo:
+Keep around the latest (by timestamp) NUM copies of the old repodata (works only for primary, filelists, other and their DB variants).
 .SS \-\-distro DISTRO
 .sp
 Distro tag and optional cpeid: \-\-distro\(aqcpeid,textname\(aq.
@@ -148,7 +151,7 @@ Which compression type to use (even for primary, filelists and other xml).
 Keep all additional metadata (not primary, filelists and other xml or sqlite files, nor their compressed variants) from source repository during update.
 .SS \-\-compatibility
 .sp
-Enforce maximal compatibility with classical createrepo.
+Enforce maximal compatibility with classical createrepo (Affects only: --retain-old-md).
 .SS \-\-retain\-old\-md\-by\-age AGE
 .sp
 During \-\-update, remove all files in repodata/ which are older then the specified period of time. (e.g. \(aq2h\(aq, \(aq30d\(aq, ...). Available units (m \- minutes, h \- hours, d \- days)

--- a/doc/mergerepo_c.8
+++ b/doc/mergerepo_c.8
@@ -62,7 +62,24 @@ Do not merge updateinfo metadata
 Which compression type to use
 .SS \-\-method MERGE_METHOD
 .sp
-Specify merge method for packages with the same name and arch (available merge methods: repo (default), ts, nvr)
+Specify merge method for packages with the same name and arch.
+.sp
+Available merge methods:
+.P
+.B repo
+.RS 3
+(default) select package from the first specified repository.
+.RE
+.sp
+.B nvr
+.RS 3
+select package with the higher version and release.
+.RE
+.sp
+.B ts
+.RS 3
+select package with the newest timestamp.
+.RE
 .SS \-\-all
 .sp
 Include all packages with the same name and arch if version or release is different. If used \-\-method argument is ignored!
@@ -81,6 +98,9 @@ Don\(aqt add a baseurl to packages that don\(aqt have one before.
 .SS \-k \-\-koji
 .sp
 Enable koji mergerepos behaviour.
+.SS \-\-simple
+.sp
+Enable koji specific simple merge mode where we keep even packages with identical NEVRAs. Only works with combination with --koji/-k.
 .SS \-\-pkgorigins
 .sp
 Enable standard mergerepos behavior while also providing the pkgorigins file for koji.

--- a/src/cmd_parser.c
+++ b/src/cmd_parser.c
@@ -133,7 +133,9 @@ static GOptionEntry cmd_entries[] =
     { "simple-md-filenames", 0, 0, G_OPTION_ARG_NONE, &(_cmd_options.simple_md_filenames),
       "Do not include the file's checksum in the metadata filename.", NULL },
     { "retain-old-md", 0, 0, G_OPTION_ARG_INT, &(_cmd_options.retain_old),
-      "Keep around the latest (by timestamp) N copies of the old repodata.", "NUM" },
+      "Specify NUM to 0 to remove all repodata present in old repomd.xml or any other positive number to keep all old repodata. "
+      "Use --compatibility flag to get the behavior of original createrepo: "
+      "Keep around the latest (by timestamp) NUM copies of the old repodata (works only for primary, filelists, other and their DB variants).", "NUM" },
     { "distro", 0, 0, G_OPTION_ARG_STRING_ARRAY, &(_cmd_options.distro_tags),
       "Distro tag and optional cpeid: --distro'cpeid,textname'.", "DISTRO" },
     { "content", 0, 0, G_OPTION_ARG_STRING_ARRAY, &(_cmd_options.content_tags),
@@ -166,7 +168,7 @@ static GOptionEntry cmd_entries[] =
       "Keep all additional metadata (not primary, filelists and other xml or sqlite files, "
       "nor their compressed variants) from source repository during update.", NULL },
     { "compatibility", 0, 0, G_OPTION_ARG_NONE, &(_cmd_options.compatibility),
-      "Enforce maximal compatibility with classical createrepo.", NULL },
+      "Enforce maximal compatibility with classical createrepo (Affects only: --retain-old-md).", NULL },
     { "retain-old-md-by-age", 0, 0, G_OPTION_ARG_STRING, &(_cmd_options.retain_old_md_by_age),
       "During --update, remove all files in repodata/ which are older "
       "then the specified period of time. (e.g. '2h', '30d', ...). "


### PR DESCRIPTION
The first commit addresses https://github.com/rpm-software-management/createrepo_c/issues/79.