### PR TITLE
Switch off html timestamps on documentation (RhBug:1731050)

### DIFF
--- a/doc/Doxyfile.in.in
+++ b/doc/Doxyfile.in.in
@@ -952,7 +952,7 @@ HTML_COLORSTYLE_GAMMA  = 80
 # page will contain the date and time when the page was generated. Setting
 # this to NO can help when comparing the output of multiple runs.
 
-HTML_TIMESTAMP         = YES
+HTML_TIMESTAMP         = NO
 
 # If the HTML_DYNAMIC_SECTIONS tag is set to YES then the generated HTML
 # documentation will contain sections that can be hidden and shown after the


### PR DESCRIPTION
This change avoids file conflicts when installing createrepo_c-devel
package for i686 and x86_64 architectures in parallel.
After switching the timestamps off the documentation html files are
identical for both builds and rpm does not consider them conflicting any
more.

https://bugzilla.redhat.com/show_bug.cgi?id=1731050