### PR TITLE
Print only a warning if package contains forbidden char

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,10 @@ IF (ENABLE_BASHCOMP)
     ENDIF (BASHCOMP_FOUND)
 ENDIF (ENABLE_BASHCOMP)
 
+OPTION(WARN_ON_FORBIDDEN_CHAR "Do not exclude rpm's containing forbidden characters from the repo. Print warning instead" OFF)
+IF (WARN_ON_FORBIDDEN_CHAR)
+    ADD_DEFINITIONS("-DWARN_ON_FORBIDDEN_CHAR=1")
+ENDIF (WARN_ON_FORBIDDEN_CHAR)
 
 # Gen manpage
 

--- a/src/xml_dump.c
+++ b/src/xml_dump.c
@@ -286,9 +286,13 @@ cr_xml_dump(cr_Package *pkg, GError **err)
     result.other     = NULL;
 
     if (cr_Package_contains_forbidden_control_chars(pkg)) {
+#ifdef WARN_ON_FORBIDDEN_CHAR
+        g_warning("Forbidden control chars found (ASCII values <32 except 9, 10 and 13) in package %s.", pkg->name);
+#else
         g_set_error(err, CREATEREPO_C_ERROR, CRE_XMLDATA,
                     "Forbidden control chars found (ASCII values <32 except 9, 10 and 13).");
         return result;
+#endif
     }
 
     if (!pkg)

--- a/src/xml_dump.c
+++ b/src/xml_dump.c
@@ -44,10 +44,17 @@ cr_xml_dump_cleanup()
 
 gboolean cr_hascontrollchars(const unsigned char *str)
 {
+    int line = 1;
+    int character = 1;
     while (*str) {
         if (*str < 32 && (*str != 9 && *str != 10 && *str != 13)) {
-            g_debug("Found control char in string '%s'", str);
+            g_debug("Found control char in string '%s' Line: %d, Row: %d", str, line, character);
             return TRUE;
+        }
+        ++character
+        if (*str == 10= {
+          ++line;
+          character = 1;
         }
         ++str;
     }

--- a/src/xml_dump.c
+++ b/src/xml_dump.c
@@ -45,8 +45,10 @@ cr_xml_dump_cleanup()
 gboolean cr_hascontrollchars(const unsigned char *str)
 {
     while (*str) {
-        if (*str < 32 && (*str != 9 && *str != 10 && *str != 13))
+        if (*str < 32 && (*str != 9 && *str != 10 && *str != 13)) {
+            g_debug("Found control char in string '%s'", str);
             return TRUE;
+        }
         ++str;
     }
 


### PR DESCRIPTION
As we need to cleanup our production repositories, before we turn the exclusion of packages on, I created this patch to only print a warning if package header/spec contains forbidden characters.