### PR TITLE
Honor umask on cache files (RhBug:1686812)

### DIFF
--- a/src/dumper_thread.c
+++ b/src/dumper_thread.c
@@ -274,6 +274,13 @@ get_checksum(const char *filename,
             g_free(template);
             goto exit;
         }
+
+        // Rewrite default permissions of tempfiles, RhBug:1686812
+        mode_t mask = umask(0777);
+        umask(mask);
+        // Files should not be executable so use only 0666
+        fchmod(fd, 0666 ^ mask);
+
         write(fd, checksum, strlen(checksum));
         close(fd);
         if (g_rename(template, cachefn) == -1)


### PR DESCRIPTION
Cache files are created with tempfile mechanism which uses default mode
of 0600, this commit changes their mode to the one specified by umask.
Original reason for this is sharing cache between multiple users
updating one repository.

https://bugzilla.redhat.com/show_bug.cgi?id=1686812

This also unifies behavior with original createrepo.