### PR TITLE
export all changelog entries in compatibility mode

### DIFF
--- a/src/cmd_parser.c
+++ b/src/cmd_parser.c
@@ -31,7 +31,6 @@
 
 
 #define ERR_DOMAIN                      CREATEREPO_C_ERROR
-#define DEFAULT_CHANGELOG_LIMIT         10
 #define DEFAULT_CHECKSUM                "sha256"
 #define DEFAULT_WORKERS                 5
 #define DEFAULT_UNIQUE_MD_FILENAMES     TRUE

--- a/src/cmd_parser.h
+++ b/src/cmd_parser.h
@@ -24,6 +24,8 @@
 #include "checksum.h"
 #include "compression_wrapper.h"
 
+#define DEFAULT_CHANGELOG_LIMIT         10
+
 
 /**
  * Command line options

--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -1059,7 +1059,11 @@ main(int argc, char **argv)
     user_data.pri_zck           = pri_cr_zck;
     user_data.fil_zck           = fil_cr_zck;
     user_data.oth_zck           = oth_cr_zck;
-    user_data.changelog_limit   = cmd_options->changelog_limit;
+    if (cmd_options->compatibility && cmd_options->changelog_limit == DEFAULT_CHANGELOG_LIMIT ) {
+      user_data.changelog_limit   = -1;
+    } else {
+      user_data.changelog_limit   = cmd_options->changelog_limit;
+    }
     user_data.location_base     = cmd_options->location_base;
     user_data.checksum_type_str = cr_checksum_name_str(cmd_options->checksum_type);
     user_data.checksum_type     = cmd_options->checksum_type;


### PR DESCRIPTION
the old python based createrepo exported all changelog entries to the
other.xml. createrepo_c limits to 10 entries.

This patch is an attempt to get all entries into the other.xml without
changing the default behavior of createrepo_c via using the
--compatibility option.