### PR TITLE
Libmagic to follow symlinks (RhBug:1776399)

### DIFF
--- a/src/compression_wrapper.c
+++ b/src/compression_wrapper.c
@@ -166,7 +166,7 @@ cr_detect_compression(const char *filename, GError **err)
 
     // No success? Let's get hardcore... (Use magic bytes)
 
-    magic_t myt = magic_open(MAGIC_MIME);
+    magic_t myt = magic_open(MAGIC_MIME | MAGIC_SYMLINK);
     if (myt == NULL) {
         g_set_error(err, ERR_DOMAIN, CRE_MAGIC,
                     "magic_open() failed: Cannot allocate the magic cookie");

--- a/src/compression_wrapper.c
+++ b/src/compression_wrapper.c
@@ -158,11 +158,11 @@ cr_detect_compression(const char *filename, GError **err)
         return CR_CW_ZCK_COMPRESSION;
     } else if (g_str_has_suffix(filename, ".xml") ||
                g_str_has_suffix(filename, ".tar") ||
+               g_str_has_suffix(filename, ".yaml") ||
                g_str_has_suffix(filename, ".sqlite"))
     {
         return CR_CW_NO_COMPRESSION;
     }
-
 
     // No success? Let's get hardcore... (Use magic bytes)
 


### PR DESCRIPTION
If the input metadata file for modifyrepo_c was a symlink the
program failed to detect compression type. This patch instructs
libmagic to follow the symlinks when guessing the mime type.

Let modules.yaml be a symlink:

$ modifyrepo_c ./modules.yaml ./repodata
Cannot open ./modules.yaml: Cannot detect compression type

https://bugzilla.redhat.com/show_bug.cgi?id=1776399