### PR TITLE
Add restart_suggested to updatecollectionpackage

### DIFF
--- a/src/python/updatecollectionpackage-py.c
+++ b/src/python/updatecollectionpackage-py.c
@@ -227,6 +227,8 @@ static PyGetSetDef updatecollectionpackage_getsetters[] = {
         "Type of checksum", OFFSET(sum_type)},
     {"reboot_suggested",    (getter)get_int, (setter)set_int,
         "Suggested reboot", OFFSET(reboot_suggested)},
+    {"restart_suggested",   (getter)get_int, (setter)set_int,
+        "Suggested restart",OFFSET(restart_suggested)},
     {NULL, NULL, NULL, NULL, NULL} /* sentinel */
 };
 

--- a/src/updateinfo.c
+++ b/src/updateinfo.c
@@ -59,6 +59,7 @@ cr_updatecollectionpackage_copy(const cr_UpdateCollectionPackage *orig)
 
     pkg->sum_type = orig->sum_type;
     pkg->reboot_suggested = orig->reboot_suggested;
+    pkg->restart_suggested = orig->restart_suggested;
 
     return pkg;
 }

--- a/src/updateinfo.h
+++ b/src/updateinfo.h
@@ -46,6 +46,7 @@ typedef struct {
     gchar *sum;
     cr_ChecksumType sum_type;
     gboolean reboot_suggested;
+    gboolean restart_suggested;
 
     GStringChunk *chunk;
 } cr_UpdateCollectionPackage;

--- a/src/xml_dump_updateinfo.c
+++ b/src/xml_dump_updateinfo.c
@@ -62,6 +62,8 @@ cr_xml_dump_updatecollectionpackages(xmlNodePtr collection, GSList *packages)
 
         if (pkg->reboot_suggested)
             xmlNewChild(package, NULL, BAD_CAST "reboot_suggested", NULL);
+        if (pkg->restart_suggested)
+            xmlNewChild(package, NULL, BAD_CAST "restart_suggested", NULL);
     }
 }
 

--- a/src/xml_parser_updateinfo.c
+++ b/src/xml_parser_updateinfo.c
@@ -60,7 +60,7 @@ typedef enum {
     STATE_SUM,
     STATE_UPDATERECORD_REBOOTSUGGESTED,
     STATE_REBOOTSUGGESTED,
-    STATE_RESTARTSUGGESTED, // Not implemented
+    STATE_RESTARTSUGGESTED,
     STATE_RELOGINSUGGESTED, // Not implemented
     NUMSTATES,
 } cr_UpdateinfoState;
@@ -96,7 +96,7 @@ static cr_StatesSwitch stateswitches[] = {
     { STATE_PACKAGE,    "filename",          STATE_FILENAME,          1 },
     { STATE_PACKAGE,    "sum",               STATE_SUM,               1 },
     { STATE_PACKAGE,    "reboot_suggested",  STATE_REBOOTSUGGESTED,   0 },
-    { STATE_PACKAGE,    "restart_suggested", STATE_RESTARTSUGGESTED,  0 }, // NI
+    { STATE_PACKAGE,    "restart_suggested", STATE_RESTARTSUGGESTED,  0 },
     { STATE_PACKAGE,    "relogin_suggested", STATE_RELOGINSUGGESTED,  0 }, // NI
     { NUMSTATES,        NULL, NUMSTATES, 0 }
 };
@@ -375,6 +375,14 @@ cr_start_handler(void *pdata, const char *element, const char **attr)
         assert(pd->updatecollectionpackage);
         package->reboot_suggested = TRUE;
         break;
+
+    case STATE_RESTARTSUGGESTED:
+        assert(pd->updateinfo);
+        assert(pd->updaterecord);
+        assert(pd->updatecollection);
+        assert(pd->updatecollectionpackage);
+        package->restart_suggested = TRUE;
+        break;
     }
 }
 
@@ -414,6 +422,7 @@ cr_end_handler(void *pdata, G_GNUC_UNUSED const char *element)
     case STATE_MODULE:
     case STATE_PKGLIST:
     case STATE_REBOOTSUGGESTED:
+    case STATE_RESTARTSUGGESTED:
     case STATE_UPDATERECORD_REBOOTSUGGESTED:
         // All elements with no text data and without need of any
         // post processing should go here

--- a/tests/python/tests/test_updatecollectionpackage.py
+++ b/tests/python/tests/test_updatecollectionpackage.py
@@ -22,6 +22,7 @@ class TestCaseUpdateCollectionPackage(unittest.TestCase):
         self.assertEqual(pkg.sum, None)
         self.assertEqual(pkg.sum_type, 0)
         self.assertEqual(pkg.reboot_suggested, 0)
+        self.assertEqual(pkg.restart_suggested, 0)
 
         pkg.name = "foo"
         pkg.version = "1.2"
@@ -33,6 +34,7 @@ class TestCaseUpdateCollectionPackage(unittest.TestCase):
         pkg.sum = "abcdef"
         pkg.sum_type = cr.SHA1
         pkg.reboot_suggested = True
+        pkg.restart_suggested = True
 
         self.assertEqual(pkg.name, "foo")
         self.assertEqual(pkg.version, "1.2")
@@ -44,3 +46,4 @@ class TestCaseUpdateCollectionPackage(unittest.TestCase):
         self.assertEqual(pkg.sum, "abcdef")
         self.assertEqual(pkg.sum_type, cr.SHA1)
         self.assertEqual(pkg.reboot_suggested, True)
+        self.assertEqual(pkg.restart_suggested, True)

--- a/tests/python/tests/test_updateinfo.py
+++ b/tests/python/tests/test_updateinfo.py
@@ -145,6 +145,7 @@ class TestCaseUpdateInfo(unittest.TestCase):
         pkg.sum = "abcdef"
         pkg.sum_type = cr.SHA1
         pkg.reboot_suggested = True
+        pkg.restart_suggested = True
 
         col = cr.UpdateCollection()
         col.shortname = "short name"
@@ -208,6 +209,7 @@ class TestCaseUpdateInfo(unittest.TestCase):
           <filename>foo.rpm</filename>
           <sum type="sha1">abcdef</sum>
           <reboot_suggested/>
+          <restart_suggested/>
         </package>
       </collection>
     </pkglist>
@@ -324,6 +326,7 @@ class TestCaseUpdateInfo(unittest.TestCase):
         pkg.sum = "abcdef"
         pkg.sum_type = cr.SHA1
         pkg.reboot_suggested = True
+        pkg.restart_suggested = True
 
         col = cr.UpdateCollection()
         col.shortname = "short name"
@@ -389,6 +392,7 @@ class TestCaseUpdateInfo(unittest.TestCase):
           <filename>foo.rpm</filename>
           <sum type="sha1">abcdef</sum>
           <reboot_suggested/>
+          <restart_suggested/>
         </package>
       </collection>
     </pkglist>

--- a/tests/test_xml_parser_updateinfo.c
+++ b/tests/test_xml_parser_updateinfo.c
@@ -102,6 +102,7 @@ test_cr_xml_parse_updateinfo_01(void)
     g_assert_cmpstr(pkg->sum, ==, "29be985e1f652cd0a29ceed6a1c49964d3618bddd22f0be3292421c8777d26c8");
     g_assert_cmpint(pkg->sum_type, ==, CR_CHECKSUM_SHA256);
     g_assert(pkg->reboot_suggested);
+    g_assert(pkg->restart_suggested);
 
     cr_updateinfo_free(ui);
 }
@@ -166,6 +167,7 @@ test_cr_xml_parse_updateinfo_02(void)
     g_assert(!pkg->sum);
     g_assert_cmpint(pkg->sum_type, ==, CR_CHECKSUM_UNKNOWN);
     g_assert(!pkg->reboot_suggested);
+    g_assert(!pkg->restart_suggested);
 
     cr_updateinfo_free(ui);
 }

--- a/tests/testdata/updateinfo_files/updateinfo_01.xml
+++ b/tests/testdata/updateinfo_files/updateinfo_01.xml
@@ -23,6 +23,7 @@
           <filename>bar-2.0.1-3.noarch.rpm</filename>
           <sum type="sha256">29be985e1f652cd0a29ceed6a1c49964d3618bddd22f0be3292421c8777d26c8</sum>
           <reboot_suggested/>
+          <restart_suggested/>
         </package>
       </collection>
     </pkglist>


### PR DESCRIPTION
As discussed here https://github.com/rpm-software-management/createrepo_c/pull/187 adding restart_suggested to packages.
Also extended the unit tests with the new field as well.