### PR TITLE
createrepo_c: use pkg href for cache lookup with --update

### DIFF
--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -627,7 +627,7 @@ main(int argc, char **argv)
 
     if (task_count && cmd_options->update) {
         int ret;
-        old_metadata = cr_metadata_new(CR_HT_KEY_FILENAME, 1, current_pkglist);
+        old_metadata = cr_metadata_new(CR_HT_KEY_HREF, 1, current_pkglist);
         cr_metadata_set_dupaction(old_metadata, CR_HT_DUPACT_REMOVEALL);
 
         if (cmd_options->outputdir)

--- a/src/dumper_thread.c
+++ b/src/dumper_thread.c
@@ -441,15 +441,17 @@ cr_dumper_thread(gpointer data, gpointer user_data)
 
     // Update stuff
     if (udata->old_metadata) {
+        char *cache_key = cr_get_cleaned_href(location_href);
+
         // We have old metadata
         g_mutex_lock(&(udata->mutex_old_md));
         md = (cr_Package *) g_hash_table_lookup(
                                 cr_metadata_hashtable(udata->old_metadata),
-                                task->filename);
+                                cache_key);
         // Remove the pkg from the hash table of old metadata, so that no other
         // thread can use it as CACHE, because later we modify it destructively
         g_hash_table_steal(cr_metadata_hashtable(udata->old_metadata),
-                                                 task->filename);
+                                                 cache_key);
         g_mutex_unlock(&(udata->mutex_old_md));
 
         if (md) {

--- a/src/load_metadata.c
+++ b/src/load_metadata.c
@@ -575,6 +575,9 @@ cr_metadata_load_xml(cr_Metadata *md,
             case CR_HT_KEY_FILENAME:
                 new_key = cr_get_filename(pkg->location_href);
                 break;
+            case CR_HT_KEY_HREF:
+                new_key = cr_get_cleaned_href(pkg->location_href);
+                break;
             case CR_HT_KEY_HASH:
                 new_key = pkg->pkgId;
                 break;

--- a/src/load_metadata.h
+++ b/src/load_metadata.h
@@ -62,6 +62,7 @@ typedef enum {
     CR_HT_KEY_NAME,                     /*!< pkg name (cr_Package ->name) */
     CR_HT_KEY_FILENAME,                 /*!< pkg filename (cr_Package
                                              ->location_href) */
+    CR_HT_KEY_HREF,                     /*!< pkg location */
     CR_HT_KEY_SENTINEL,                 /*!< last element, terminator, .. */
 } cr_HashTableKey;
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -367,6 +367,21 @@ cr_get_filename(const char *filepath)
     return filename;
 }
 
+char *
+cr_get_cleaned_href(const char *filepath)
+{
+    char *filename;
+
+    if (!filepath)
+        return NULL;
+
+    filename = (char *) filepath;
+
+    while (filename[0] == '.' && filename[1] == '/')
+        filename += 2;
+
+    return filename;
+}
 
 gboolean
 cr_copy_file(const char *src, const char *in_dst, GError **err)

--- a/src/misc.h
+++ b/src/misc.h
@@ -139,6 +139,13 @@ struct cr_HeaderRangeStruct cr_get_header_byte_range(const char *filename,
  */
 char *cr_get_filename(const char *filepath);
 
+/** Return pointer to the rest of string after './' prefix.
+ * (e.g. for "././foo/bar" returns "foo/bar")
+ * @param filepath      path
+ * @return              pointer into the path
+ */
+char *cr_get_cleaned_href(const char *filepath);
+
 /** Download a file from the URL into the in_dst via curl handle.
  * @param handle        CURL handle
  * @param url           source url


### PR DESCRIPTION
Duplicated RPM filenames in traversed directory caused cache misses
before (since duplicates are removed from the caches entirely).

Lookup by package location minimizes cache misses a lot.  This required
inventing a new hashing type CR_HT_KEY_HREF.