### PR TITLE
recycle pkglist with --update

### DIFF
--- a/createrepo_c.bash
+++ b/createrepo_c.bash
@@ -70,7 +70,7 @@ _cr_createrepo()
             --retain-old-md-by-age --cachedir --local-sqlite
             --cut-dirs --location-prefix
             --deltas --oldpackagedirs
-            --num-deltas --max-delta-rpm-size' -- "$2" ) )
+            --num-deltas --max-delta-rpm-size --recycle-pkglist' -- "$2" ) )
     else
         COMPREPLY=( $( compgen -d -- "$2" ) )
     fi

--- a/doc/createrepo_c.8
+++ b/doc/createrepo_c.8
@@ -90,6 +90,14 @@ Specify a text file which contains the complete list of files to include in the 
 .SS \-n \-\-includepkg PACKAGE
 .sp
 Specify pkgs to include on the command line. Takes urls as well as local paths.
+.SS \-\-recycle\-pkglist
+.sp
+Useful only with \fB\-\-update\fR.  Read the list of packages from old metadata,
+and reuse it instead of (perhaps expensive) directory traversal.  This doesn't
+collide with explicitly selected packages by \fB\-\-pkglist\fR or
+\fB\-\-includepkg\fR, such packages are appended to the recycled list.
+This option is useful for I/O optimal repo modifications (package removal by
+\fB\-\-exclude\fR, and additions with \fB\-\-pkglist\fR).
 .SS \-o \-\-outputdir URL
 .sp
 Optional output directory.

--- a/src/cmd_parser.c
+++ b/src/cmd_parser.c
@@ -64,6 +64,7 @@ struct CmdOptions _cmd_options = {
 
         .zck_compression            = FALSE,
         .zck_dict_dir               = NULL,
+        .recycle_pkglist            = FALSE,
     };
 
 
@@ -202,6 +203,10 @@ static GOptionEntry cmd_entries[] =
       "Checksum type to be used in repomd.xml", "CHECKSUM_TYPE"},
     { "error-exit-val", 0, 0, G_OPTION_ARG_NONE, &(_cmd_options.error_exit_val),
       "Exit with retval 2 if there were any errors during processing", NULL },
+    { "recycle-pkglist", 0, 0, G_OPTION_ARG_NONE, &(_cmd_options.recycle_pkglist),
+      "Read the list of packages from old metadata directory and re-use it.  This "
+      "option is only useful with --update (complements --pkglist and friends).",
+      NULL },
     { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL },
 };
 

--- a/src/cmd_parser.h
+++ b/src/cmd_parser.h
@@ -136,6 +136,7 @@ struct CmdOptions {
     char *checksum_cachedir;    /*!< Path to cachedir */
     GSList *oldpackagedirs_paths; /*!< paths to look for older pkgs to delta against */
 
+    gboolean recycle_pkglist;
 };
 
 /**

--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -627,7 +627,7 @@ main(int argc, char **argv)
 
     if (task_count && cmd_options->update) {
         int ret;
-        old_metadata = cr_metadata_new(CR_HT_KEY_FILENAME, 1, current_pkglist);
+        old_metadata = cr_metadata_new(CR_HT_KEY_HREF, 1, current_pkglist);
         cr_metadata_set_dupaction(old_metadata, CR_HT_DUPACT_REMOVEALL);
 
         if (cmd_options->outputdir)

--- a/src/dumper_thread.c
+++ b/src/dumper_thread.c
@@ -441,15 +441,17 @@ cr_dumper_thread(gpointer data, gpointer user_data)
 
     // Update stuff
     if (udata->old_metadata) {
+        char *cache_key = cr_get_cleaned_href(location_href);
+
         // We have old metadata
         g_mutex_lock(&(udata->mutex_old_md));
         md = (cr_Package *) g_hash_table_lookup(
                                 cr_metadata_hashtable(udata->old_metadata),
-                                task->filename);
+                                cache_key);
         // Remove the pkg from the hash table of old metadata, so that no other
         // thread can use it as CACHE, because later we modify it destructively
         g_hash_table_steal(cr_metadata_hashtable(udata->old_metadata),
-                                                 task->filename);
+                                                 cache_key);
         g_mutex_unlock(&(udata->mutex_old_md));
 
         if (md) {

--- a/src/load_metadata.c
+++ b/src/load_metadata.c
@@ -575,6 +575,9 @@ cr_metadata_load_xml(cr_Metadata *md,
             case CR_HT_KEY_FILENAME:
                 new_key = cr_get_filename(pkg->location_href);
                 break;
+            case CR_HT_KEY_HREF:
+                new_key = cr_get_cleaned_href(pkg->location_href);
+                break;
             case CR_HT_KEY_HASH:
                 new_key = pkg->pkgId;
                 break;

--- a/src/load_metadata.h
+++ b/src/load_metadata.h
@@ -62,6 +62,7 @@ typedef enum {
     CR_HT_KEY_NAME,                     /*!< pkg name (cr_Package ->name) */
     CR_HT_KEY_FILENAME,                 /*!< pkg filename (cr_Package
                                              ->location_href) */
+    CR_HT_KEY_HREF,                     /*!< pkg location */
     CR_HT_KEY_SENTINEL,                 /*!< last element, terminator, .. */
 } cr_HashTableKey;
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -367,6 +367,21 @@ cr_get_filename(const char *filepath)
     return filename;
 }
 
+char *
+cr_get_cleaned_href(const char *filepath)
+{
+    char *filename;
+
+    if (!filepath)
+        return NULL;
+
+    filename = (char *) filepath;
+
+    while (filename[0] == '.' && filename[1] == '/')
+        filename += 2;
+
+    return filename;
+}
 
 gboolean
 cr_copy_file(const char *src, const char *in_dst, GError **err)

--- a/src/misc.h
+++ b/src/misc.h
@@ -139,6 +139,13 @@ struct cr_HeaderRangeStruct cr_get_header_byte_range(const char *filename,
  */
 char *cr_get_filename(const char *filepath);
 
+/** Return pointer to the rest of string after './' prefix.
+ * (e.g. for "././foo/bar" returns "foo/bar")
+ * @param filepath      path
+ * @return              pointer into the path
+ */
+char *cr_get_cleaned_href(const char *filepath);
+
 /** Download a file from the URL into the in_dst via curl handle.
  * @param handle        CURL handle
  * @param url           source url


### PR DESCRIPTION
```
    createrepo_c: add --recycle-pkglist option
    
    This option is useful e.g. for very large repositories in copr [1] where
    we need to update the repodata after each package build or package
    removal.  Re-generating everything from scratch with --update is simply
    too expensive (actually even the directory traversal is) so the only
    only viable option would be to maintain complete list of packages
    manually, and use '--pkglist --no-stat'.
    
    With '--recycle-pkglist' we can avoid the additional work with separate
    pkglists.  Adding new builds can be done just like
      $ createrepo_c --no-stat --update --recycle-pkglist --pkglist <sth>
    and removing something can be done with
      $ createrepo_c --no-stat --update --recycle-pkglist --exclude <sth>
    
    [1] https://pagure.io/copr/copr/pull-request/1150
```