### PR TITLE
Switch updateinfo to explicitly include bool values (RhBug:1772466)

### DIFF
--- a/src/xml_dump_updateinfo.c
+++ b/src/xml_dump_updateinfo.c
@@ -61,9 +61,9 @@ cr_xml_dump_updatecollectionpackages(xmlNodePtr collection, GSList *packages)
         }
 
         if (pkg->reboot_suggested)
-            xmlNewChild(package, NULL, BAD_CAST "reboot_suggested", NULL);
+            xmlNewChild(package, NULL, BAD_CAST "reboot_suggested", "True");
         if (pkg->restart_suggested)
-            xmlNewChild(package, NULL, BAD_CAST "restart_suggested", NULL);
+            xmlNewChild(package, NULL, BAD_CAST "restart_suggested", "True");
     }
 }
 
@@ -168,7 +168,7 @@ cr_xml_dump_updateinforecord_internal(xmlNodePtr root, cr_UpdateRecord *rec)
     cr_xmlNewTextChild_c(update, NULL, BAD_CAST "solution", BAD_CAST rec->solution);
 
     if (rec->reboot_suggested)
-        xmlNewChild(update, NULL, BAD_CAST "reboot_suggested", NULL);
+        xmlNewChild(update, NULL, BAD_CAST "reboot_suggested", "True");
 
     // References
     cr_xml_dump_updateinforecord_references(update, rec->references);

--- a/tests/python/tests/test_updateinfo.py
+++ b/tests/python/tests/test_updateinfo.py
@@ -114,7 +114,7 @@ class TestCaseUpdateInfo(unittest.TestCase):
     <summary>summary</summary>
     <description>description</description>
     <solution>solution</solution>
-    <reboot_suggested/>
+    <reboot_suggested>True</reboot_suggested>
     <references/>
     <pkglist/>
   </update>
@@ -208,8 +208,8 @@ class TestCaseUpdateInfo(unittest.TestCase):
         <package name="foo" version="1.2" release="3" epoch="0" arch="x86" src="foo.src.rpm">
           <filename>foo.rpm</filename>
           <sum type="sha1">abcdef</sum>
-          <reboot_suggested/>
-          <restart_suggested/>
+          <reboot_suggested>True</reboot_suggested>
+          <restart_suggested>True</restart_suggested>
         </package>
       </collection>
     </pkglist>
@@ -295,7 +295,7 @@ class TestCaseUpdateInfo(unittest.TestCase):
         <package name="foo" version="1.2" release="3" epoch="0" arch="x86" src="foo.src.rpm">
           <filename>foo.rpm</filename>
           <sum type="sha1">abcdef</sum>
-          <reboot_suggested/>
+          <reboot_suggested>True</reboot_suggested>
         </package>
       </collection>
     </pkglist>
@@ -380,7 +380,7 @@ class TestCaseUpdateInfo(unittest.TestCase):
     <summary>summary</summary>
     <description>description</description>
     <solution>solution</solution>
-    <reboot_suggested/>
+    <reboot_suggested>True</reboot_suggested>
     <references>
       <reference href="href" id="id" type="type" title="title"/>
     </references>
@@ -391,8 +391,8 @@ class TestCaseUpdateInfo(unittest.TestCase):
         <package name="foo" version="1.2" release="3" epoch="0" arch="x86" src="foo.src.rpm">
           <filename>foo.rpm</filename>
           <sum type="sha1">abcdef</sum>
-          <reboot_suggested/>
-          <restart_suggested/>
+          <reboot_suggested>True</reboot_suggested>
+          <restart_suggested>True</restart_suggested>
         </package>
       </collection>
     </pkglist>

--- a/tests/python/tests/test_updaterecord.py
+++ b/tests/python/tests/test_updaterecord.py
@@ -134,7 +134,7 @@ class TestCaseUpdateRecord(unittest.TestCase):
     <summary>summary</summary>
     <description>description</description>
     <solution>solution</solution>
-    <reboot_suggested/>
+    <reboot_suggested>True</reboot_suggested>
     <references/>
     <pkglist/>
   </update>


### PR DESCRIPTION
Elements <restart_suggested> and both <reboot_suggested> were previously
outputed just as an empty element which meant they are true, this patch
changes it to explicitly output:
<reboot_suggested>True</reboot_suggested>.

However we still don't output False values, in that case the element is
simply omitted.

https://bugzilla.redhat.com/show_bug.cgi?id=1772466