### PR TITLE
Fix crash when passing invalid path to --update-md-path (RhBug:1762697)

### DIFF
--- a/doc/createrepo_c.8
+++ b/doc/createrepo_c.8
@@ -77,7 +77,7 @@ Do not generate sqlite databases in the repository.
 If metadata already exists in the outputdir and an rpm is unchanged (based on file size and mtime) since the metadata was generated, reuse the existing metadata rather than recalculating it. In the case of a large repository with only a few new or modified rpms this can significantly reduce I/O and processing time.
 .SS \-\-update\-md\-path
 .sp
-Use the existing repodata for \-\-update from this path.
+Existing metadata from this path are loaded and reused in addition to those present in the outputdir (works only with \-\-update). Can be specified multiple times.
 .SS \-\-skip\-stat
 .sp
 Skip the stat() call on a \-\-update, assumes if the filename is the same then the file is still the same (only use this if you\(aqre fairly trusting or gullible).

--- a/src/cmd_parser.c
+++ b/src/cmd_parser.c
@@ -104,7 +104,8 @@ static GOptionEntry cmd_entries[] =
       "large repository with only a few new or modified rpms "
       "this can significantly reduce I/O and processing time.", NULL },
     { "update-md-path", 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &(_cmd_options.update_md_paths),
-      "Use the existing repodata for --update from this path.", NULL },
+      "Existing metadata from this path are loaded and reused in addition to those "
+      "present in the outputdir (works only with --update). Can be specified multiple times.", NULL },
     { "skip-stat", 0, 0, G_OPTION_ARG_NONE, &(_cmd_options.skip_stat),
       "Skip the stat() call on a --update, assumes if the filename is the same "
       "then the file is still the same (only use this if you're fairly "

--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -457,6 +457,9 @@ load_old_metadata(cr_Metadata **md,
             g_clear_pointer(md_location, cr_metadatalocation_free);
             g_critical("%s\n",tmp_err->message);
             exit(tmp_err->code);
+        } else {
+            g_debug("Old metadata from default outputdir not found: %s",tmp_err->message);
+            g_clear_error(&tmp_err);
         }
     }
 

--- a/src/locate_metadata.c
+++ b/src/locate_metadata.c
@@ -355,8 +355,11 @@ cr_locate_metadata(const char *repopath, gboolean ignore_sqlite, GError **err)
         ret = cr_get_local_metadata(repopath, ignore_sqlite);
     }
 
-    if (ret)
+    if (ret) {
         ret->original_url = g_strdup(repopath);
+    } else {
+        g_set_error(err, ERR_DOMAIN, CRE_IO, "Metadata not found at %s.", repopath);
+    }
 
 #ifndef WITH_LIBMODULEMD
     if (ret) {

--- a/utils/gen_rst.py
+++ b/utils/gen_rst.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import sys
 import re
@@ -70,13 +70,13 @@ def parse_arguments_from_c_file(filename):
     try:
         content = open(filename, "r").read()
     except IOError:
-        print "Error: Cannot open file %s" % filename
+        print("Error: Cannot open file %s" % filename)
         return args
 
     re_cmd_entries = re.compile(r"\s*(static|const)[ ]+GOptionEntry[^{]*{(?P<entries>.*)\s*NULL\s*}[,]?\s*};", re.MULTILINE|re.DOTALL)
     match = re_cmd_entries.search(content)
     if not match:
-        print "Warning: Cannot find GOptionEntry section in %s" % filename
+        print("Warning: Cannot find GOptionEntry section in %s" % filename)
         return args
 
     re_single_entry = re.compile(r"""{\s*"(?P<long_name>[^"]*)"\s*,        # long name
@@ -134,7 +134,7 @@ def parse_arguments_from_c_file(filename):
         entry_match = re_single_entry.search(raw_entries_str[start:])
     # End while
 
-    print >> sys.stderr, "Loaded %2d arguments" % (i,)
+    print("Loaded %2d arguments" % (i,), file=sys.stderr)
     return args
 
 
@@ -147,7 +147,7 @@ if __name__ == "__main__":
     options, args = parser.parse_args()
 
     if len(args) < 1:
-        print >> sys.stderr, "Error: Must specify a input filename. (Example: ../src/cmd_parser.c)"
+        print("Error: Must specify a input filename. (Example: ../src/cmd_parser.c)", file=sys.stderr)
         sys.exit(1)
 
     args = parse_arguments_from_c_file(args[0])
@@ -181,7 +181,7 @@ if __name__ == "__main__":
 
     ret = info.gen_rst()
     if not ret:
-        print >> sys.stderr, "Error: Rst has not been generated"
+        print("Error: Rst has not been generated", file=sys.stderr)
         sys.exit(1)
 
-    print ret
+    print(ret)


### PR DESCRIPTION
This fixes a crash that occurred when specifying `--update-md-path` with invalid path.

https://bugzilla.redhat.com/show_bug.cgi?id=1762697

And this PR contains tests for this:
https://github.com/rpm-software-management/ci-dnf-stack/pull/757

I also tried to make the documentation for the option more friendly (which led me to updating the script which generates it to python3).