### PR TITLE
Set global_exit_status on sigint so that .repodata are cleaned up

### DIFF
--- a/src/createrepo_shared.c
+++ b/src/createrepo_shared.c
@@ -65,6 +65,7 @@ static void
 sigint_catcher(int sig)
 {
     g_message("%s catched: Terminating...", strsignal(sig));
+    *global_exit_status = 1;
     exit(1);
 }
 


### PR DESCRIPTION
global_exit_status is used by failure_exit_cleanup function, which is
setup by atexit(), to determine whether to clean up temp metadata.

This resolves issue https://github.com/rpm-software-management/createrepo_c/issues/188