### PR TITLE
Finish support for OpenSUSE updateinfo (RhBug:1779751)

### DIFF
--- a/src/python/updatecollectionpackage-py.c
+++ b/src/python/updatecollectionpackage-py.c
@@ -229,6 +229,8 @@ static PyGetSetDef updatecollectionpackage_getsetters[] = {
         "Suggested reboot", OFFSET(reboot_suggested)},
     {"restart_suggested",   (getter)get_int, (setter)set_int,
         "Suggested restart",OFFSET(restart_suggested)},
+    {"relogin_suggested",   (getter)get_int, (setter)set_int,
+        "Suggested relogin",OFFSET(relogin_suggested)},
     {NULL, NULL, NULL, NULL, NULL} /* sentinel */
 };
 

--- a/src/updateinfo.c
+++ b/src/updateinfo.c
@@ -60,6 +60,7 @@ cr_updatecollectionpackage_copy(const cr_UpdateCollectionPackage *orig)
     pkg->sum_type = orig->sum_type;
     pkg->reboot_suggested = orig->reboot_suggested;
     pkg->restart_suggested = orig->restart_suggested;
+    pkg->relogin_suggested = orig->relogin_suggested;
 
     return pkg;
 }

--- a/src/updateinfo.h
+++ b/src/updateinfo.h
@@ -47,6 +47,7 @@ typedef struct {
     cr_ChecksumType sum_type;
     gboolean reboot_suggested;
     gboolean restart_suggested;
+    gboolean relogin_suggested;
 
     GStringChunk *chunk;
 } cr_UpdateCollectionPackage;

--- a/src/xml_dump_updateinfo.c
+++ b/src/xml_dump_updateinfo.c
@@ -64,6 +64,8 @@ cr_xml_dump_updatecollectionpackages(xmlNodePtr collection, GSList *packages)
             xmlNewChild(package, NULL, BAD_CAST "reboot_suggested", "True");
         if (pkg->restart_suggested)
             xmlNewChild(package, NULL, BAD_CAST "restart_suggested", "True");
+        if (pkg->relogin_suggested)
+            xmlNewChild(package, NULL, BAD_CAST "relogin_suggested", "True");
     }
 }
 

--- a/src/xml_parser_updateinfo.c
+++ b/src/xml_parser_updateinfo.c
@@ -61,7 +61,7 @@ typedef enum {
     STATE_UPDATERECORD_REBOOTSUGGESTED,
     STATE_REBOOTSUGGESTED,
     STATE_RESTARTSUGGESTED,
-    STATE_RELOGINSUGGESTED, // Not implemented
+    STATE_RELOGINSUGGESTED,
     NUMSTATES,
 } cr_UpdateinfoState;
 
@@ -97,7 +97,7 @@ static cr_StatesSwitch stateswitches[] = {
     { STATE_PACKAGE,    "sum",               STATE_SUM,               1 },
     { STATE_PACKAGE,    "reboot_suggested",  STATE_REBOOTSUGGESTED,   0 },
     { STATE_PACKAGE,    "restart_suggested", STATE_RESTARTSUGGESTED,  0 },
-    { STATE_PACKAGE,    "relogin_suggested", STATE_RELOGINSUGGESTED,  0 }, // NI
+    { STATE_PACKAGE,    "relogin_suggested", STATE_RELOGINSUGGESTED,  0 },
     { NUMSTATES,        NULL, NUMSTATES, 0 }
 };
 
@@ -386,6 +386,14 @@ cr_start_handler(void *pdata, const char *element, const char **attr)
         assert(pd->updatecollectionpackage);
         package->restart_suggested = TRUE;
         break;
+
+    case STATE_RELOGINSUGGESTED:
+        assert(pd->updateinfo);
+        assert(pd->updaterecord);
+        assert(pd->updatecollection);
+        assert(pd->updatecollectionpackage);
+        package->relogin_suggested = TRUE;
+        break;
     }
 }
 
@@ -426,6 +434,7 @@ cr_end_handler(void *pdata, G_GNUC_UNUSED const char *element)
     case STATE_PKGLIST:
     case STATE_REBOOTSUGGESTED:
     case STATE_RESTARTSUGGESTED:
+    case STATE_RELOGINSUGGESTED:
     case STATE_UPDATERECORD_REBOOTSUGGESTED:
         // All elements with no text data and without need of any
         // post processing should go here

--- a/tests/python/tests/test_updatecollectionpackage.py
+++ b/tests/python/tests/test_updatecollectionpackage.py
@@ -23,6 +23,7 @@ class TestCaseUpdateCollectionPackage(unittest.TestCase):
         self.assertEqual(pkg.sum_type, 0)
         self.assertEqual(pkg.reboot_suggested, 0)
         self.assertEqual(pkg.restart_suggested, 0)
+        self.assertEqual(pkg.relogin_suggested, 0)
 
         pkg.name = "foo"
         pkg.version = "1.2"
@@ -35,6 +36,7 @@ class TestCaseUpdateCollectionPackage(unittest.TestCase):
         pkg.sum_type = cr.SHA1
         pkg.reboot_suggested = True
         pkg.restart_suggested = True
+        pkg.relogin_suggested = True
 
         self.assertEqual(pkg.name, "foo")
         self.assertEqual(pkg.version, "1.2")
@@ -47,3 +49,4 @@ class TestCaseUpdateCollectionPackage(unittest.TestCase):
         self.assertEqual(pkg.sum_type, cr.SHA1)
         self.assertEqual(pkg.reboot_suggested, True)
         self.assertEqual(pkg.restart_suggested, True)
+        self.assertEqual(pkg.relogin_suggested, True)

--- a/tests/python/tests/test_updateinfo.py
+++ b/tests/python/tests/test_updateinfo.py
@@ -146,6 +146,7 @@ class TestCaseUpdateInfo(unittest.TestCase):
         pkg.sum_type = cr.SHA1
         pkg.reboot_suggested = True
         pkg.restart_suggested = True
+        pkg.relogin_suggested = True
 
         col = cr.UpdateCollection()
         col.shortname = "short name"
@@ -210,6 +211,7 @@ class TestCaseUpdateInfo(unittest.TestCase):
           <sum type="sha1">abcdef</sum>
           <reboot_suggested>True</reboot_suggested>
           <restart_suggested>True</restart_suggested>
+          <relogin_suggested>True</relogin_suggested>
         </package>
       </collection>
     </pkglist>
@@ -327,6 +329,7 @@ class TestCaseUpdateInfo(unittest.TestCase):
         pkg.sum_type = cr.SHA1
         pkg.reboot_suggested = True
         pkg.restart_suggested = True
+        pkg.relogin_suggested = True
 
         col = cr.UpdateCollection()
         col.shortname = "short name"
@@ -393,6 +396,7 @@ class TestCaseUpdateInfo(unittest.TestCase):
           <sum type="sha1">abcdef</sum>
           <reboot_suggested>True</reboot_suggested>
           <restart_suggested>True</restart_suggested>
+          <relogin_suggested>True</relogin_suggested>
         </package>
       </collection>
     </pkglist>

--- a/tests/python/tests/test_updateinfo.py
+++ b/tests/python/tests/test_updateinfo.py
@@ -62,6 +62,14 @@ class TestCaseUpdateInfo(unittest.TestCase):
         self.assertEqual(len(rec.references), 0)
         self.assertEqual(len(rec.collections), 0)
 
+        rec = cr.UpdateRecord()
+        rec.issued_date = int(now.timestamp())
+        ui.append(rec)
+
+        self.assertEqual(len(ui.updates), 2)
+        rec = ui.updates[1]
+        self.assertEqual(rec.issued_date, int(now.timestamp()))
+
     def test_updateinfo_xml_dump_01(self):
         ui = cr.UpdateInfo()
         xml = ui.xml_dump()
@@ -350,7 +358,7 @@ class TestCaseUpdateInfo(unittest.TestCase):
         rec.version = "version"
         rec.id = "id"
         rec.title = "title"
-        rec.issued_date = now
+        rec.issued_date = int(now.timestamp())
         rec.updated_date = now
         rec.rights = "rights"
         rec.release = "release"
@@ -374,7 +382,7 @@ class TestCaseUpdateInfo(unittest.TestCase):
   <update from="from" status="status" type="type" version="version">
     <id>id</id>
     <title>title</title>
-    <issued date="%(now)s"/>
+    <issued date="%(now_epoch)s"/>
     <updated date="%(now)s"/>
     <rights>rights</rights>
     <release>release</release>
@@ -402,4 +410,4 @@ class TestCaseUpdateInfo(unittest.TestCase):
     </pkglist>
   </update>
 </updates>
-""" % {"now": now.strftime("%Y-%m-%d %H:%M:%S")})
+""" % {"now": now.strftime("%Y-%m-%d %H:%M:%S"), "now_epoch": now.strftime('%s')})

--- a/tests/test_xml_parser_updateinfo.c
+++ b/tests/test_xml_parser_updateinfo.c
@@ -260,6 +260,12 @@ test_cr_xml_parse_updateinfo_03(void)
     g_assert_cmpstr(pkg->version, ==, "0.7");
     g_assert_cmpstr(pkg->filename, ==, "duck-0.7-1.noarch.rpm");
 
+    update = g_slist_nth_data(ui->updates, 5);
+
+    g_assert_cmpstr(update->id, ==, "RHEA-2012:0060");
+    g_assert_cmpstr(update->issued_date, ==, "1555429284");
+    g_assert_cmpstr(update->updated_date, ==, "2018-07-29 06:00:01 UTC");
+
     cr_updateinfo_free(ui);
 }
 

--- a/tests/test_xml_parser_updateinfo.c
+++ b/tests/test_xml_parser_updateinfo.c
@@ -103,6 +103,7 @@ test_cr_xml_parse_updateinfo_01(void)
     g_assert_cmpint(pkg->sum_type, ==, CR_CHECKSUM_SHA256);
     g_assert(pkg->reboot_suggested);
     g_assert(pkg->restart_suggested);
+    g_assert(pkg->relogin_suggested);
 
     cr_updateinfo_free(ui);
 }
@@ -168,6 +169,7 @@ test_cr_xml_parse_updateinfo_02(void)
     g_assert_cmpint(pkg->sum_type, ==, CR_CHECKSUM_UNKNOWN);
     g_assert(!pkg->reboot_suggested);
     g_assert(!pkg->restart_suggested);
+    g_assert(!pkg->relogin_suggested);
 
     cr_updateinfo_free(ui);
 }

--- a/tests/testdata/updateinfo_files/updateinfo_01.xml
+++ b/tests/testdata/updateinfo_files/updateinfo_01.xml
@@ -24,6 +24,7 @@
           <sum type="sha256">29be985e1f652cd0a29ceed6a1c49964d3618bddd22f0be3292421c8777d26c8</sum>
           <reboot_suggested/>
           <restart_suggested/>
+          <relogin_suggested/>
         </package>
       </collection>
     </pkglist>

--- a/tests/testdata/updateinfo_files/updateinfo_03.xml
+++ b/tests/testdata/updateinfo_files/updateinfo_03.xml
@@ -113,7 +113,7 @@
   <id>RHEA-2012:0060</id>
   <title>Duck_0.8_Erratum</title>
   <release>1</release>
-  <issued date="2018-01-29 16:08:09"/>
+  <issued date="1555429284"/>
   <updated date="2018-07-29 06:00:01 UTC"/>
   <description>Duck_0.8_Erratum description</description>
   <pkglist>


### PR DESCRIPTION
Adds relogin_suggested field and enables epoch time format in Python API for issued_date field.

Also extends unit tests for these features.

https://bugzilla.redhat.com/show_bug.cgi?id=1779751