### PR TITLE
Copy updateCollectionModule on assignment to prevent bogus data (RhBug:1821781)

### DIFF
--- a/src/python/updatecollection-py.c
+++ b/src/python/updatecollection-py.c
@@ -293,15 +293,19 @@ set_str(_UpdateCollectionObject *self, PyObject *value, void *member_offset)
 static int
 set_module(_UpdateCollectionObject *self, PyObject *value, void *member_offset)
 {
+    cr_UpdateCollectionModule *orig, *new;
+
     if (check_UpdateCollectionStatus(self))
         return -1;
     if (!UpdateCollectionModuleObject_Check(value) && value != Py_None) {
         PyErr_SetString(PyExc_TypeError, "Module or None expected!");
         return -1;
     }
-    cr_UpdateCollectionModule *module = UpdateCollectionModule_FromPyObject(value);
+    orig = UpdateCollectionModule_FromPyObject(value);
+    new = cr_updatecollectionmodule_copy(orig);
+
     cr_UpdateCollection *collection = self->collection;
-    *((cr_UpdateCollectionModule **) ((size_t) collection + (size_t) member_offset)) = module;
+    *((cr_UpdateCollectionModule **) ((size_t) collection + (size_t) member_offset)) = new;
 
     return 0;
 }

--- a/tests/python/tests/test_updatecollection.py
+++ b/tests/python/tests/test_updatecollection.py
@@ -64,3 +64,33 @@ class TestCaseUpdateCollection(unittest.TestCase):
         self.assertEqual(pkg.sum, "abcdef")
         self.assertEqual(pkg.sum_type, cr.SHA1)
         self.assertEqual(pkg.reboot_suggested, True)
+
+    def test_updatecollection_setters_when_module_going_out_of_scope(self):
+        def create_collection_scope():
+            col = cr.UpdateCollection()
+            col.name = "name"
+
+            module = cr.UpdateCollectionModule()
+            module.name = "kangaroo"
+            module.stream = "0"
+            module.version = 20180730223407
+            module.context = "deadbeef"
+            module.arch = "noarch"
+
+            col.module = module
+
+            return col
+
+        col = create_collection_scope()
+        self.assertTrue(col)
+
+        self.assertEqual(col.name, "name")
+
+        # Check if the appended module was appended properly
+        module = col.module
+        self.assertEqual(module.name, "kangaroo")
+        self.assertEqual(module.stream, "0")
+        self.assertEqual(module.version, 20180730223407)
+        self.assertEqual(module.context, "deadbeef")
+        self.assertEqual(module.arch, "noarch")
+


### PR DESCRIPTION
When assigned updateCollectionModule goes out of scope it gets freed
because its references drop to 0, this resulted in bogus data because
the memory was still being used.

This patch ensures we pass the updateCollectionModule by value (it gets
copied on assignment) just like everywhere else in the updateinfo api.

Also adds a test for this case.

https://bugzilla.redhat.com/show_bug.cgi?id=1821781