### PR TITLE
Add --arch-expand option

### DIFF
--- a/doc/mergerepo_c.8
+++ b/doc/mergerepo_c.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MERGEREPO_C  "2019-07-18" "" ""
+.TH MERGEREPO_C  "2020-04-29" "" ""
 .SH NAME
 mergerepo_c \- Merge multiple rpm-md format repositories together
 .
@@ -116,6 +116,9 @@ Enable koji specific simple merge mode where we keep even packages with identica
 .SS \-\-pkgorigins
 .sp
 Enable standard mergerepos behavior while also providing the pkgorigins file for koji.
+.SS \-\-arch\-expand
+.sp
+Add multilib architectures for specified archlist and expand all of them. Only works with combination with \-\-archlist.
 .SS \-g \-\-groupfile GROUPFILE
 .sp
 Path to groupfile to include in metadata.

--- a/src/mergerepo_c.h
+++ b/src/mergerepo_c.h
@@ -70,6 +70,7 @@ struct CmdOptions {
     gboolean koji;
     gboolean koji_simple;
     gboolean pkgorigins;
+    gboolean arch_expand;
     char *groupfile;
     char *blocked;
 


### PR DESCRIPTION
This is a separate option that does a subset of --koji functionality:
For specified --archlist it adds multilib arches and then expands all of
them.

I have also created some tests for our CI stack: https://github.com/rpm-software-management/ci-dnf-stack/pull/821

For issue: https://github.com/rpm-software-management/createrepo_c/issues/213