### PR TITLE
Never do dir walk when --recycle-pkglist specified

### DIFF
--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -132,7 +132,7 @@ fill_pool(GThreadPool *pool,
     }
 
 
-    if (cmd_options->pkglist && !cmd_options->include_pkgs) {
+    if ((cmd_options->pkglist || cmd_options->recycle_pkglist) && !cmd_options->include_pkgs) {
         g_warning("Used pkglist doesn't contain any useful items");
     } else if (!(cmd_options->include_pkgs)) {
         // --pkglist (or --includepkg, or --recycle-pkglist) is not supplied


### PR DESCRIPTION
When there are no packages in exisiting repodata and --update with
--recycle-pkglist is used createrepo_c shouldn't do the dir walk, the
situation is the same as using empty pkglist.

Fixes issue: https://github.com/rpm-software-management/createrepo_c/issues/222