### PR TITLE
Add module metadata support to createrepo_c (RhBug:1795936) 

### DIFF
--- a/doc/createrepo_c.8
+++ b/doc/createrepo_c.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH CREATEREPO_C  "2019-07-19" "" ""
+.TH CREATEREPO_C  "2020-07-02" "" ""
 .SH NAME
 createrepo_c \- Create rpm-md format (xml-rpm-metadata) repository
 .
@@ -35,6 +35,25 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .SH SYNOPSIS
 .sp
 createrepo_c [options] <directory>
+.SH DESCRIPTION
+.sp
+Uses rpm packages from <directory> to create repodata.
+.sp
+If compiled with libmodulemd support modular metadata inside <directory> identified by the patterns below are automatically collected, merged and added to the repodata.
+.sp
+The patterns are:
+.INDENT 0.0
+.INDENT 3.5
+.INDENT 0.0
+.IP \(bu 2
+*.modulemd.yaml (recommended file name: N:S:V:C:A.modulemd.yaml)
+.IP \(bu 2
+*.modulemd\-defaults.yaml (recommended file name: N.modulemd\-defaults.yaml)
+.IP \(bu 2
+modules.yaml (recommended way of importing multiple documents at once)
+.UNINDENT
+.UNINDENT
+.UNINDENT
 .SH OPTIONS
 .SS \-V \-\-version
 .sp

--- a/src/cmd_parser.c
+++ b/src/cmd_parser.c
@@ -637,5 +637,6 @@ free_options(struct CmdOptions *options)
     cr_slist_free_full(options->l_update_md_paths, g_free);
     cr_slist_free_full(options->distro_cpeids, g_free);
     cr_slist_free_full(options->distro_values, g_free);
+    cr_slist_free_full(options->modulemd_metadata, g_free);
     g_slist_free(options->oldpackagedirs_paths);
 }

--- a/src/cmd_parser.h
+++ b/src/cmd_parser.h
@@ -135,6 +135,7 @@ struct CmdOptions {
                                      is used */
     char *checksum_cachedir;    /*!< Path to cachedir */
     GSList *oldpackagedirs_paths; /*!< paths to look for older pkgs to delta against */
+    GSList *modulemd_metadata;  /*!< paths to all modulemd metadata */
 
     gboolean recycle_pkglist;
 };

--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -770,28 +770,25 @@ main(int argc, char **argv)
     // Setup compression types
     const char *xml_compression_suffix = NULL;
     const char *sqlite_compression_suffix = NULL;
-    const char *prestodelta_compression_suffix = NULL;
+    const char *compression_suffix = NULL;
     cr_CompressionType xml_compression = CR_CW_GZ_COMPRESSION;
     cr_CompressionType sqlite_compression = CR_CW_BZ2_COMPRESSION;
-    cr_CompressionType groupfile_compression = CR_CW_GZ_COMPRESSION;
-    cr_CompressionType prestodelta_compression = CR_CW_GZ_COMPRESSION;
+    cr_CompressionType compression = CR_CW_GZ_COMPRESSION;
 
     if (cmd_options->compression_type != CR_CW_UNKNOWN_COMPRESSION) {
-        sqlite_compression      = cmd_options->compression_type;
-        groupfile_compression   = cmd_options->compression_type;
-        prestodelta_compression = cmd_options->compression_type;
+        sqlite_compression = cmd_options->compression_type;
+        compression        = cmd_options->compression_type;
     }
 
     if (cmd_options->general_compression_type != CR_CW_UNKNOWN_COMPRESSION) {
-        xml_compression         = cmd_options->general_compression_type;
-        sqlite_compression      = cmd_options->general_compression_type;
-        groupfile_compression   = cmd_options->general_compression_type;
-        prestodelta_compression = cmd_options->general_compression_type;
+        xml_compression    = cmd_options->general_compression_type;
+        sqlite_compression = cmd_options->general_compression_type;
+        compression        = cmd_options->general_compression_type;
     }
 
     xml_compression_suffix = cr_compression_suffix(xml_compression);
     sqlite_compression_suffix = cr_compression_suffix(sqlite_compression);
-    prestodelta_compression_suffix = cr_compression_suffix(prestodelta_compression);
+    compression_suffix = cr_compression_suffix(compression);
 
 
     // Create and open new compressed files
@@ -1362,7 +1359,7 @@ main(int argc, char **argv)
     if (new_groupfile_metadatum) {
         additional_metadata_rec = cr_create_repomd_records_for_groupfile_metadata(new_groupfile_metadatum,
                                                                                   additional_metadata_rec,
-                                                                                  groupfile_compression, 
+                                                                                  compression,
                                                                                   cmd_options->repomd_checksum_type);
 
         //NOTE(amatej): Now we can add groupfile metadata to the additional_metadata list, for unified handlig while zck compressing
@@ -1620,7 +1617,7 @@ main(int argc, char **argv)
         cr_ContentStat *prestodelta_zck_stat = NULL;
 
         filename = g_strconcat("prestodelta.xml",
-                               prestodelta_compression_suffix,
+                               compression_suffix,
                                NULL);
         outdeltadir = g_build_filename(out_dir, OUTDELTADIR, NULL);
         prestodelta_xml_filename = g_build_filename(tmp_out_repo,
@@ -1668,7 +1665,7 @@ main(int argc, char **argv)
         // 3) Generate prestodelta.xml file
         prestodelta_stat = cr_contentstat_new(cmd_options->repomd_checksum_type, NULL);
         prestodelta_cr_file = cr_xmlfile_sopen_prestodelta(prestodelta_xml_filename,
-                                                           prestodelta_compression,
+                                                           compression,
                                                            prestodelta_stat,
                                                            &tmp_err);
         if (!prestodelta_cr_file) {
@@ -1676,7 +1673,7 @@ main(int argc, char **argv)
             g_clear_error(&tmp_err);
             goto deltaerror;
         }
-        if (cmd_options->zck_compression && prestodelta_compression != CR_CW_ZCK_COMPRESSION) {
+        if (cmd_options->zck_compression && compression != CR_CW_ZCK_COMPRESSION) {
             filename = g_strconcat("prestodelta.xml",
                                    cr_compression_suffix(CR_CW_ZCK_COMPRESSION),
                                    NULL);

--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -726,6 +726,30 @@ main(int argc, char **argv)
     g_slist_free(current_pkglist);
     current_pkglist = NULL;
     GSList *additional_metadata = NULL;
+
+    // Setup compression types
+    const char *xml_compression_suffix = NULL;
+    const char *sqlite_compression_suffix = NULL;
+    const char *compression_suffix = NULL;
+    cr_CompressionType xml_compression = CR_CW_GZ_COMPRESSION;
+    cr_CompressionType sqlite_compression = CR_CW_BZ2_COMPRESSION;
+    cr_CompressionType compression = CR_CW_GZ_COMPRESSION;
+
+    if (cmd_options->compression_type != CR_CW_UNKNOWN_COMPRESSION) {
+        sqlite_compression = cmd_options->compression_type;
+        compression        = cmd_options->compression_type;
+    }
+
+    if (cmd_options->general_compression_type != CR_CW_UNKNOWN_COMPRESSION) {
+        xml_compression    = cmd_options->general_compression_type;
+        sqlite_compression = cmd_options->general_compression_type;
+        compression        = cmd_options->general_compression_type;
+    }
+
+    xml_compression_suffix = cr_compression_suffix(xml_compression);
+    sqlite_compression_suffix = cr_compression_suffix(sqlite_compression);
+    compression_suffix = cr_compression_suffix(compression);
+
     cr_Metadatum *new_groupfile_metadatum = NULL;
 
     // Groupfile specified as argument 
@@ -765,31 +789,6 @@ main(int argc, char **argv)
 
     cr_metadatalocation_free(old_metadata_location);
     old_metadata_location = NULL;
-
-
-    // Setup compression types
-    const char *xml_compression_suffix = NULL;
-    const char *sqlite_compression_suffix = NULL;
-    const char *compression_suffix = NULL;
-    cr_CompressionType xml_compression = CR_CW_GZ_COMPRESSION;
-    cr_CompressionType sqlite_compression = CR_CW_BZ2_COMPRESSION;
-    cr_CompressionType compression = CR_CW_GZ_COMPRESSION;
-
-    if (cmd_options->compression_type != CR_CW_UNKNOWN_COMPRESSION) {
-        sqlite_compression = cmd_options->compression_type;
-        compression        = cmd_options->compression_type;
-    }
-
-    if (cmd_options->general_compression_type != CR_CW_UNKNOWN_COMPRESSION) {
-        xml_compression    = cmd_options->general_compression_type;
-        sqlite_compression = cmd_options->general_compression_type;
-        compression        = cmd_options->general_compression_type;
-    }
-
-    xml_compression_suffix = cr_compression_suffix(xml_compression);
-    sqlite_compression_suffix = cr_compression_suffix(sqlite_compression);
-    compression_suffix = cr_compression_suffix(compression);
-
 
     // Create and open new compressed files
     cr_XmlFile *pri_cr_file;

--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -356,8 +356,8 @@ cr_create_repomd_records_for_groupfile_metadata(const cr_Metadatum *group_metada
                                                   compressed_record_type,
                                                   NULL
                                               ));
-    //TODO(amatej): replace nth_data with ->next->data
-    cr_repomd_record_compress_and_fill(g_slist_nth_data(additional_metadata_rec, 1),
+
+    cr_repomd_record_compress_and_fill(additional_metadata_rec->next->data,
                                        additional_metadata_rec->data,
                                        repomd_checksum_type,
                                        comp_type,

--- a/utils/gen_rst.py
+++ b/utils/gen_rst.py
@@ -43,6 +43,14 @@ class Info(object):
                 rst += "%s\n\n" % line
             rst += "\n"
 
+        # Add description
+        if self.description:
+            rst += "DESCRIPTION\n"
+            rst += "===========\n\n"
+            for line in self.description:
+                rst += "%s\n\n" % line
+            rst += "\n"
+
         # Add options
         rst += "OPTIONS\n"
         rst += "=======\n"
@@ -177,7 +185,14 @@ if __name__ == "__main__":
         info = Info(NAME,
                 summary="Create rpm-md format (xml-rpm-metadata) repository",
                 synopsis=["%s [options] <directory>" % (NAME,)],
+                description=["Uses rpm packages from <directory> to create repodata.",
+                             "If compiled with libmodulemd support modular metadata inside <directory> identified by the patterns below are automatically collected, merged and added to the repodata.",
+                             "The patterns are:",
+                             " - \*.modulemd.yaml (recommended file name: N:S:V:C:A.modulemd.yaml)",
+                             " - \*.modulemd-defaults.yaml (recommended file name: N.modulemd-defaults.yaml)",
+                             " - modules.yaml (recommended way of importing multiple documents at once)"],
                 options=args)
+
 
     ret = info.gen_rst()
     if not ret:


### PR DESCRIPTION
The new behavior is described in the associated bugzilla:
https://bugzilla.redhat.com/show_bug.cgi?id=1795936#c3

This resolves https://github.com/rpm-software-management/createrepo_c/issues/134 (except it doesn't do any validation against present rpms, the created repository can have completely unrelated modular metadata and packages in it).

Tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/860