### PR TITLE
Parse xml snippet in smaller parts (RhBug:1859689)

### DIFF
--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -842,7 +842,8 @@ main(int argc, char **argv)
                                                                      &failures,
                                                                      &tmp_err);
             if (!result) {
-                g_critical("Could not update module index from file %s: %s", element->data, tmp_err->message);
+                g_critical("Could not update module index from file %s: %s", element->data,
+                           (tmp_err ? tmp_err->message : "Unknown error"));
                 g_clear_error(&tmp_err);
                 g_clear_pointer(&moduleindex, g_object_unref);
                 g_clear_pointer(&merger, g_object_unref);
@@ -895,7 +896,8 @@ main(int argc, char **argv)
         CR_FILE *modules_file = NULL;
         modules_file = cr_open(modules_metadata_path, CR_CW_MODE_WRITE, compression, &tmp_err);
         if (modules_file == NULL) {
-            g_critical("%s: Cannot open source file %s: %s", __func__, modules_metadata_path, tmp_err->message);
+            g_critical("%s: Cannot open source file %s: %s", __func__, modules_metadata_path,
+                       (tmp_err ? tmp_err->message : "Unknown error"));
             g_clear_error(&tmp_err);
             free(moduleindex_str);
             free(modules_metadata_path);

--- a/tests/python/tests/test_xml_parser.py
+++ b/tests/python/tests/test_xml_parser.py
@@ -476,6 +476,42 @@ class TestCaseXmlParserFilelists(unittest.TestCase):
         self.assertEqual(userdata["pkgcb_calls"], 2)
         self.assertEqual(userdata["warnings"], [])
 
+    def test_xml_parser_filelists_snippet_huge(self):
+
+        userdata = {
+                "pkgs": [],
+                "pkgcb_calls": 0,
+                "warnings": []
+            }
+
+        def newpkgcb(pkgId, name, arch):
+            pkg = cr.Package()
+            userdata["pkgs"].append(pkg)
+            return pkg
+
+        def pkgcb(pkg):
+            userdata["pkgcb_calls"] += 1
+
+        def warningcb(warn_type, msg):
+            userdata["warnings"].append((warn_type, msg))
+
+        # generete huge filelists snippet
+        content = """
+                  <package pkgid="68743563000b2a85e7d9d7ce318719217f3bfee6167cd862efd201ff96c1ecbb" name="flat-remix-icon-theme" arch="noarch">
+                  <version epoch="0" ver="0.0.20200511" rel="1.fc33"/>
+                  """
+        for i in range(145951):
+            content += "<file>/usr/share/icons/Flat-Remix-Yellow/status/symbolic/user-available-symbolic.svg</file>"
+        content += "</package>"
+
+        cr.xml_parse_filelists_snippet(content, newpkgcb, pkgcb, warningcb)
+
+        self.assertEqual([pkg.name for pkg in userdata["pkgs"]],
+            ['flat-remix-icon-theme'])
+        self.assertEqual(userdata["pkgcb_calls"], 1)
+        self.assertEqual(userdata["warnings"], [])
+
+
 
     def test_xml_parser_filelists_repo02_only_pkgcb(self):
 


### PR DESCRIPTION
If string passed to xmlParseChunk (function froml libxml2) is too big the function errors out, its safer to parse the snippet in
smaller parts.

Also adds a unit test for this case.

https://bugzilla.redhat.com/show_bug.cgi?id=1859689


The third commit is unrelated and fixes an issue of accessing possible NULL pointer to `tmp_err`.
