### PR TITLE
Add the section number to the manual pages.

### DIFF
--- a/doc/createrepo_c.8
+++ b/doc/createrepo_c.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH CREATEREPO_C  "2020-07-02" "" ""
+.TH CREATEREPO_C 8 "2020-07-02" "" ""
 .SH NAME
 createrepo_c \- Create rpm-md format (xml-rpm-metadata) repository
 .

--- a/doc/mergerepo_c.8
+++ b/doc/mergerepo_c.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MERGEREPO_C  "2020-04-29" "" ""
+.TH MERGEREPO_C 8 "2020-04-29" "" ""
 .SH NAME
 mergerepo_c \- Merge multiple rpm-md format repositories together
 .

--- a/doc/modifyrepo_c.8
+++ b/doc/modifyrepo_c.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MODIFYREPO_C  "2019-07-18" "" ""
+.TH MODIFYREPO_C 8 "2019-07-18" "" ""
 .SH NAME
 modifyrepo_c \- Modify a repomd.xml of rpm-md format repository
 .

--- a/doc/sqliterepo_c.8
+++ b/doc/sqliterepo_c.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH SQLITEREPO_C  "2017-02-23" "" ""
+.TH SQLITEREPO_C 8 "2017-02-23" "" ""
 .SH NAME
 sqliterepo_c \- Generate sqlite db files for a repository in rpm-md format
 .

--- a/utils/gen_manpage.sh
+++ b/utils/gen_manpage.sh
@@ -14,7 +14,7 @@ fi
 MY_DIR=`dirname $0`
 MY_DIR="$MY_DIR/"
 
-python $MY_DIR/gen_rst.py $1 | rst2man > $5/createrepo_c.8
-python $MY_DIR/gen_rst.py $2 --mergerepo | rst2man > $5/mergerepo_c.8
-python $MY_DIR/gen_rst.py $3 --modifyrepo | rst2man > $5/modifyrepo_c.8
-python $MY_DIR/gen_rst.py $4 --sqliterepo | rst2man > $5/sqliterepo_c.8
+python3 $MY_DIR/gen_rst.py $1 | rst2man > $5/createrepo_c.8
+python3 $MY_DIR/gen_rst.py $2 --mergerepo | rst2man > $5/mergerepo_c.8
+python3 $MY_DIR/gen_rst.py $3 --modifyrepo | rst2man > $5/modifyrepo_c.8
+python3 $MY_DIR/gen_rst.py $4 --sqliterepo | rst2man > $5/sqliterepo_c.8

--- a/utils/gen_rst.py
+++ b/utils/gen_rst.py
@@ -32,6 +32,9 @@ class Info(object):
         if self.copyright:
             rst += ":Copyright: %s\n" % self.copyright
 
+        # Add manual page section
+        rst += ":Manual section: 8\n"
+
         # Add date
         rst += ":Date: $Date: %s $\n\n" % datetime.datetime.strftime(datetime.datetime.utcnow(), format="%F %X")
 


### PR DESCRIPTION
Hi,

First, thanks a lot for writing and maintaining this implementation of createrepo!

What do you think about this trivial patch that corrects the invocation of the ".TH" (title) macro, adding the missing section 8 parameter? It seems that whatever generated the troff file was aware that there should have been another value there - there are two spaces between the program name and modification date parameters - but it was somehow invoked in such a way as to not place anything there, not even an empty string in troff syntax.

BTW, are these manual pages really generated from a ReST source? If so, where is that source, and how is the generation performed? Or have they been written up once, converted to troff format, and then edited directly in troff format from then on? If it is the latter, may I humbly suggest using the mdoc troff macro set instead for, at least IMHO, a bit more readability? I could help with converting - okay, well, rewriting really - the manual pages into troff mdoc format.

Thanks again for createrepo-c and all the related libraries, and keep up the great work!

G'luck,
Peter
