### PR TITLE
Introduce changelog metadata in commit messages

### DIFF
--- a/.git-commit-template
+++ b/.git-commit-template
@@ -1,0 +1,16 @@
+
+
+# In addition to regular commit message, you can uncomment and fill in the
+# following to include this change in the released RPM package changelog:
+
+# = changelog =
+# msg:
+# type:
+# resolves:
+# related:
+
+# msg        = message to be included in the changelog
+# type       = one of: bugfix/enhancement/security
+# resolves   = URLs to bugs or issues resolved by this commit
+# related    = URLs to any related bugs or issues
+

--- a/README.md
+++ b/README.md
@@ -177,6 +177,36 @@ Note: When compiling createrepo_c without libmodulemd support add ``WITH_LIBMODU
 In original createrepo ``sha`` is a nickname for the ``sha1`` checksum.
 Createrepo_c mimics this behaviour.
 
+## Contribution
+
+Here's the most direct way to get your work merged into the project.
+
+1. Fork the project
+1. Clone down your fork
+1. Implement your feature or bug fix and commit changes
+1. If the change fixes a bug at [Red Hat bugzilla](https://bugzilla.redhat.com/), or if it is important to the end user, add the following block to the commit message:
+    
+       = changelog =
+       msg:           message to be included in the changelog
+       type:          one of: bugfix/enhancement/security (this field is required when message is present)
+       resolves:      URLs to bugs or issues resolved by this commit (can be specified multiple times)
+       related:       URLs to any related bugs or issues (can be specified multiple times)
+
+   * For example::
+
+         = changelog =
+         msg: Enhance error handling when locating repositories
+         type: bugfix
+         resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1762697
+
+   * For your convenience, you can also use git commit template by running the following command in the top-level directory of this project:
+
+         git config commit.template ./.git-commit-template
+
+1. In a separate commit, add your name and email into the [authors file](https://github.com/rpm-software-management/createrepo_c/blob/master/AUTHORS) as a reward for your generosity
+1. Push the branch to your fork
+1. Send a pull request for your branch
+
 ---------------------------------------------------
 
 # Differences in behavior between createrepo_c and createrepo


### PR DESCRIPTION
Add Contribution section into README, including the guidelines for
adding changelog metadata to the commit messages. Thanks to this,
changelog can be automatically generated while staying useful.