### PR TITLE
Fix memory leaks in python extension code

### DIFF
--- a/src/python/contentstat-py.c
+++ b/src/python/contentstat-py.c
@@ -201,7 +201,9 @@ set_str(_ContentStatObject *self, PyObject *value, void *member_offset)
         return -1;
     }
     cr_ContentStat *rec = self->stat;
-    char *str = g_strdup(PyObject_ToStrOrNull(value));
+    PyObject *pybytes = PyObject_ToPyBytesOrNull(value);
+    char *str = g_strdup(PyBytes_AsString(pybytes));
+    Py_XDECREF(pybytes);
     *((char **) ((size_t) rec + (size_t) member_offset)) = str;
     return 0;
 }

--- a/src/python/locate_metadata-py.c
+++ b/src/python/locate_metadata-py.c
@@ -142,12 +142,8 @@ getitem(_MetadataLocationObject *self, PyObject *pykey)
         return NULL;
     }
 
-    if (PyUnicode_Check(pykey)) {
-        pykey = PyUnicode_AsUTF8String(pykey);
-    }
-
+    pykey = PyObject_ToPyBytesOrNull(pykey);
     key = PyBytes_AsString(pykey);
-
     value = NULL;
 
     if (!strcmp(key, "primary")) {
@@ -186,14 +182,18 @@ getitem(_MetadataLocationObject *self, PyObject *pykey)
             for (GSList *elem = self->ml->additional_metadata; elem; elem=g_slist_next(elem)){
                 PyList_Append(list, PyUnicode_FromString(((cr_Metadatum *)(elem->data))->name));
             }
+            Py_XDECREF(pykey);
             return list;
         }
     }
 
-    if (value)
+    Py_XDECREF(pykey);
+
+    if (value) {
         return PyUnicode_FromString(value);
-    else
+    } else {
         Py_RETURN_NONE;
+    }
 }
 
 static PyMappingMethods mapping_methods = {

--- a/src/python/package-py.c
+++ b/src/python/package-py.c
@@ -416,11 +416,7 @@ set_str(_PackageObject *self, PyObject *value, void *member_offset)
     if (!pkg->chunk)
         pkg->chunk = g_string_chunk_new(0);
 
-    if (PyUnicode_Check(value)) {
-        value = PyUnicode_AsUTF8String(value);
-    }
-
-    char *str = g_string_chunk_insert(pkg->chunk, PyBytes_AsString(value));
+    char *str = PyObject_ToChunkedString(value, pkg->chunk);
     *((char **) ((size_t) pkg + (size_t) member_offset)) = str;
     return 0;
 }

--- a/src/python/repomd-py.c
+++ b/src/python/repomd-py.c
@@ -402,8 +402,7 @@ set_str(_RepomdObject *self, PyObject *value, void *member_offset)
     }
     cr_Repomd *repomd = self->repomd;
 
-    char *str = cr_safe_string_chunk_insert(repomd->chunk,
-                                            PyObject_ToStrOrNull(value));
+    char *str = PyObject_ToChunkedString(value, repomd->chunk);
     *((char **) ((size_t) repomd + (size_t) member_offset)) = str;
     return 0;
 }

--- a/src/python/repomdrecord-py.c
+++ b/src/python/repomdrecord-py.c
@@ -384,8 +384,7 @@ set_str(_RepomdRecordObject *self, PyObject *value, void *member_offset)
         return -1;
     }
     cr_RepomdRecord *rec = self->record;
-    char *str = cr_safe_string_chunk_insert(rec->chunk,
-                                            PyObject_ToStrOrNull(value));
+    char *str = PyObject_ToChunkedString(value, rec->chunk);
     *((char **) ((size_t) rec + (size_t) member_offset)) = str;
     return 0;
 }

--- a/src/python/typeconversion.c
+++ b/src/python/typeconversion.c
@@ -50,7 +50,16 @@ PyErr_ToGError(GError **err)
                     "Error while error handling");
     } else {
         if (PyUnicode_Check(pystr)) {
-            pystr = PyUnicode_AsUTF8String(pystr);
+            PyObject *pybytes = PyUnicode_AsUTF8String(pystr);
+            Py_DECREF(pystr);
+
+            if (!pybytes) {
+                PyErr_Clear();
+                g_set_error(err, ERR_DOMAIN, CRE_XMLPARSER,
+                            "Error while error handling");
+                return;
+            }
+            pystr = pybytes;
         }
         g_set_error(err, ERR_DOMAIN, CRE_XMLPARSER,
                     "%s", PyBytes_AsString(pystr));

--- a/src/python/typeconversion.h
+++ b/src/python/typeconversion.h
@@ -27,7 +27,7 @@
 void PyErr_ToGError(GError **err);
 
 PyObject *PyUnicodeOrNone_FromString(const char *str);
-char *PyObject_ToStrOrNull(PyObject *pyobj);
+PyObject *PyObject_ToPyBytesOrNull(PyObject *pyobj);
 char *PyObject_ToChunkedString(PyObject *pyobj, GStringChunk *chunk);
 
 PyObject *PyObject_FromDependency(cr_Dependency *dep);

--- a/src/python/updatecollection-py.c
+++ b/src/python/updatecollection-py.c
@@ -284,8 +284,7 @@ set_str(_UpdateCollectionObject *self, PyObject *value, void *member_offset)
         return -1;
     }
     cr_UpdateCollection *rec = self->collection;
-    char *str = cr_safe_string_chunk_insert(rec->chunk,
-                                            PyObject_ToStrOrNull(value));
+    char *str = PyObject_ToChunkedString(value, rec->chunk);
     *((char **) ((size_t) rec + (size_t) member_offset)) = str;
     return 0;
 }

--- a/src/python/updatecollectionmodule-py.c
+++ b/src/python/updatecollectionmodule-py.c
@@ -177,14 +177,8 @@ set_str(_UpdateCollectionModuleObject *self, PyObject *value, void *member_offse
         return -1;
     }
 
-    if (PyUnicode_Check(value)) {
-        value = PyUnicode_AsUTF8String(value);
-    }
-
     cr_UpdateCollectionModule *module = self->module;
-    char *str = cr_safe_string_chunk_insert(module->chunk,
-                                            PyObject_ToStrOrNull(value));
-
+    char *str = PyObject_ToChunkedString(value, module->chunk);
     *((char **) ((size_t) module + (size_t) member_offset)) = str;
     return 0;
 }

--- a/src/python/updatecollectionpackage-py.c
+++ b/src/python/updatecollectionpackage-py.c
@@ -200,8 +200,7 @@ set_str(_UpdateCollectionPackageObject *self, PyObject *value, void *member_offs
         return -1;
     }
     cr_UpdateCollectionPackage *pkg = self->pkg;
-    char *str = cr_safe_string_chunk_insert(pkg->chunk,
-                                            PyObject_ToStrOrNull(value));
+    char *str = PyObject_ToChunkedString(value, pkg->chunk);
     *((char **) ((size_t) pkg + (size_t) member_offset)) = str;
     return 0;
 }

--- a/src/python/updaterecord-py.c
+++ b/src/python/updaterecord-py.c
@@ -366,8 +366,7 @@ set_str(_UpdateRecordObject *self, PyObject *value, void *member_offset)
         return -1;
     }
     cr_UpdateRecord *rec = self->record;
-    char *str = cr_safe_string_chunk_insert(rec->chunk,
-                                            PyObject_ToStrOrNull(value));
+    char *str = PyObject_ToChunkedString(value, rec->chunk);
     *((char **) ((size_t) rec + (size_t) member_offset)) = str;
     return 0;
 }

--- a/src/python/updatereference-py.c
+++ b/src/python/updatereference-py.c
@@ -170,14 +170,8 @@ set_str(_UpdateReferenceObject *self, PyObject *value, void *member_offset)
         return -1;
     }
 
-    if (PyUnicode_Check(value)) {
-        value = PyUnicode_AsUTF8String(value);
-    }
-
     cr_UpdateReference *ref = self->reference;
-    char *str = cr_safe_string_chunk_insert(ref->chunk,
-                                            PyObject_ToStrOrNull(value));
-
+    char *str = PyObject_ToChunkedString(value, ref->chunk);
     *((char **) ((size_t) ref + (size_t) member_offset)) = str;
     return 0;
 }


### PR DESCRIPTION
fixes: #230 (bz [#1893459](https://bugzilla.redhat.com/show_bug.cgi?id=1893459))

Additionally fixes a couple of other memory leaks.  Completely removes the ```PyObject_ToStrOrNull()``` function which cannot possibly work without leaking memory.