### PR TITLE
Fix Python deprication (PY_SSIZE_T_CLEAN)

### DIFF
--- a/src/python/compression_wrapper-py.c
+++ b/src/python/compression_wrapper-py.c
@@ -17,6 +17,7 @@
  * USA.
  */
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <assert.h>
 #include <stddef.h>
@@ -205,7 +206,7 @@ static PyObject *
 py_write(_CrFileObject *self, PyObject *args)
 {
     char *str;
-    int len;
+    Py_ssize_t len;
     GError *tmp_err = NULL;
 
     if (!PyArg_ParseTuple(args, "s#:set_num_of_pkgs", &str, &len))


### PR DESCRIPTION
PyArg_ParseTuple() and formats which use # require the PY_SSIZE_T_CLEAN
macro since python 3.10

For: https://github.com/rpm-software-management/createrepo_c/issues/234
This should also fix: https://bugzilla.redhat.com/show_bug.cgi?id=1891785