### PR TITLE
Revert back to old API of cr_compress_file_with_stat and cr_compress_file

### DIFF
--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -842,7 +842,7 @@ main(int argc, char **argv)
                                                                      &failures,
                                                                      &tmp_err);
             if (!result) {
-                g_critical("Could not update module index from file %s: %s", element->data,
+                g_critical("Could not update module index from file %s: %s", (char *) element->data,
                            (tmp_err ? tmp_err->message : "Unknown error"));
                 g_clear_error(&tmp_err);
                 g_clear_pointer(&moduleindex, g_object_unref);

--- a/src/misc.c
+++ b/src/misc.c
@@ -481,15 +481,16 @@ cr_compress_file_with_stat(const char *src,
         // If destination is dir use filename from src + compression suffix
         dst = g_strconcat(dst, cr_get_filename(src), c_suffix, NULL);
     } else if (c_suffix && !g_str_has_suffix(dst, c_suffix)) {
-        cr_CompressionType old_type = cr_detect_compression(src, &tmp_err);
+        // If destination is missing compression suffix or has a different one, use specified compression suffix
+        cr_CompressionType old_type = cr_detect_compression(dst, &tmp_err);
         if (tmp_err) {
-            g_debug("%s: Unable to detect compression type of %s", __func__, src);
+            g_debug("%s: Unable to detect compression type of %s, using the filename as is.", __func__, dst);
             g_clear_error(&tmp_err);
-        } else if (old_type != CR_CW_NO_COMPRESSION) {
+        } else if (old_type == CR_CW_NO_COMPRESSION) {
+            dst = g_strconcat(dst, c_suffix, NULL);
+        } else {
             _cleanup_free_ gchar *tmp_file = g_strndup(dst, strlen(dst) - strlen(cr_compression_suffix(old_type)));
-            dst = g_strconcat(tmp_file,
-                              c_suffix,
-                              NULL);
+            dst = g_strconcat(tmp_file, c_suffix, NULL);
         }
     }
 

--- a/src/misc.h
+++ b/src/misc.h
@@ -186,7 +186,7 @@ gboolean cr_copy_file(const char *src,
 
 /** Compress file.
  * @param src           source filename
- * @param dst           pointer to destination (If dst is dir, filename of src +
+ * @param dst           destination (If dst is dir, filename of src +
  *                      compression suffix is used.
  *                      If dst is NULL, src + compression suffix is used)
  * @param comtype       type of compression
@@ -197,7 +197,7 @@ gboolean cr_copy_file(const char *src,
  * @return              cr_Error return code
  */
 int cr_compress_file_with_stat(const char *src,
-                               char **dst,
+                               const char *dst,
                                cr_CompressionType comtype,
                                cr_ContentStat *stat,
                                const char *zck_dict_dir,

--- a/src/modifyrepo_shared.c
+++ b/src/modifyrepo_shared.c
@@ -120,7 +120,7 @@ cr_write_file(gchar *repopath, cr_ModifyRepoTask *task,
         g_debug("%s: Copy & compress operation %s -> %s",
                  __func__, src_fn, dst_fn);
 
-        if (cr_compress_file(src_fn, &dst_fn, compress_type,
+        if (cr_compress_file(src_fn, dst_fn, compress_type,
                              task->zck_dict_dir, TRUE, err) != CRE_OK) {
             g_debug("%s: Copy & compress operation failed", __func__);
             return NULL;

--- a/src/python/misc-py.c
+++ b/src/python/misc-py.c
@@ -49,7 +49,7 @@ py_compress_file_with_stat(G_GNUC_UNUSED PyObject *self, PyObject *args)
             return NULL;
     }
 
-    cr_compress_file_with_stat(src, &dst, type, contentstat, NULL, FALSE, &tmp_err);
+    cr_compress_file_with_stat(src, dst, type, contentstat, NULL, FALSE, &tmp_err);
     if (tmp_err) {
         nice_exception(&tmp_err, NULL);
         return NULL;

--- a/src/threads.c
+++ b/src/threads.c
@@ -101,7 +101,7 @@ cr_compressing_thread(gpointer data, G_GNUC_UNUSED gpointer user_data)
                                 NULL);
 
     cr_compress_file_with_stat(task->src,
-                               &(task->dst),
+                               task->dst,
                                task->type,
                                task->stat,
                                task->zck_dict_dir,

--- a/tests/test_misc.c
+++ b/tests/test_misc.c
@@ -548,7 +548,7 @@ compressfile_test_text_file(Copyfiletest *copyfiletest,
     GError *tmp_err = NULL;
 
     g_assert(!g_file_test(copyfiletest->dst_file, G_FILE_TEST_EXISTS));
-    ret = cr_compress_file(TEST_TEXT_FILE, &(copyfiletest->dst_file),
+    ret = cr_compress_file(TEST_TEXT_FILE, copyfiletest->dst_file,
                            CR_CW_GZ_COMPRESSION, NULL, FALSE, &tmp_err);
     g_assert(!tmp_err);
     g_assert_cmpint(ret, ==, CRE_OK);
@@ -574,7 +574,7 @@ compressfile_with_stat_test_text_file(Copyfiletest *copyfiletest,
     g_assert(!tmp_err);
 
     g_assert(!g_file_test(copyfiletest->dst_file, G_FILE_TEST_EXISTS));
-    ret = cr_compress_file_with_stat(TEST_TEXT_FILE, &copyfiletest->dst_file,
+    ret = cr_compress_file_with_stat(TEST_TEXT_FILE, copyfiletest->dst_file,
                                      CR_CW_GZ_COMPRESSION, stat, NULL, FALSE,
                                      &tmp_err);
     g_assert(!tmp_err);
@@ -600,23 +600,26 @@ compressfile_with_stat_test_gz_file_gz_output(Copyfiletest *copyfiletest,
     g_assert(stat);
     g_assert(!tmp_err);
 
-    g_assert(!g_file_test(copyfiletest->dst_file, G_FILE_TEST_EXISTS));
-    ret = cr_compress_file_with_stat(TEST_TEXT_FILE_GZ, &copyfiletest->dst_file,
+    char * dst_full_name = g_strconcat(copyfiletest->dst_file, ".gz", NULL);
+
+    g_assert(!g_file_test(dst_full_name, G_FILE_TEST_EXISTS));
+    ret = cr_compress_file_with_stat(TEST_TEXT_FILE_GZ, dst_full_name,
                                      CR_CW_GZ_COMPRESSION, stat, NULL, FALSE,
                                      &tmp_err);
     g_assert(!tmp_err);
     g_assert_cmpint(ret, ==, CRE_OK);
-    g_assert(g_file_test(copyfiletest->dst_file, G_FILE_TEST_IS_REGULAR));
+    g_assert(g_file_test(dst_full_name, G_FILE_TEST_IS_REGULAR));
     checksum = cr_checksum_file(TEST_TEXT_FILE, CR_CHECKSUM_SHA256, NULL);
     g_assert_cmpstr(stat->checksum, ==, checksum);
 
     //assert content is readable after decompression and recompression
     char buf[30];
-    read_file(copyfiletest->dst_file, CR_CW_GZ_COMPRESSION, buf, 30);
+    read_file(dst_full_name, CR_CW_GZ_COMPRESSION, buf, 30);
     g_assert(g_strrstr(buf, "Lorem ipsum dolor sit amet"));
 
     cr_contentstat_free(stat, &tmp_err);
     g_assert(!tmp_err);
+    free(dst_full_name);
 }
 
 
@@ -626,20 +629,24 @@ compressfile_test_gz_file_xz_output(Copyfiletest *copyfiletest,
 {
     int ret;
     GError *tmp_err = NULL;
-    g_assert(!g_file_test(copyfiletest->dst_file, G_FILE_TEST_EXISTS));
-    ret = cr_compress_file(TEST_TEXT_FILE_GZ, &copyfiletest->dst_file,
+
+    char * dst_full_name = g_strconcat(copyfiletest->dst_file, ".xz", NULL);
+
+    g_assert(!g_file_test(dst_full_name, G_FILE_TEST_EXISTS));
+    ret = cr_compress_file(TEST_TEXT_FILE_GZ, dst_full_name,
                                      CR_CW_XZ_COMPRESSION, NULL, FALSE,
                                      &tmp_err);
     g_assert(!tmp_err);
     g_assert_cmpint(ret, ==, CRE_OK);
-    g_assert(g_file_test(copyfiletest->dst_file, G_FILE_TEST_IS_REGULAR));
+    g_assert(g_file_test(dst_full_name, G_FILE_TEST_IS_REGULAR));
 
     //assert content is readable after decompression and recompression
     char buf[30];
-    read_file(copyfiletest->dst_file, CR_CW_XZ_COMPRESSION, buf, 30);
+    read_file(dst_full_name, CR_CW_XZ_COMPRESSION, buf, 30);
     g_assert(g_strrstr(buf, "Lorem ipsum dolor sit amet"));
 
     g_assert(!tmp_err);
+    free(dst_full_name);
 }
 
 
@@ -649,20 +656,24 @@ compressfile_test_xz_file_gz_output(Copyfiletest *copyfiletest,
 {
     int ret;
     GError *tmp_err = NULL;
-    g_assert(!g_file_test(copyfiletest->dst_file, G_FILE_TEST_EXISTS));
-    ret = cr_compress_file(TEST_TEXT_FILE_XZ, &copyfiletest->dst_file,
+
+    char * dst_full_name = g_strconcat(copyfiletest->dst_file, ".gz", NULL);
+
+    g_assert(!g_file_test(dst_full_name, G_FILE_TEST_EXISTS));
+    ret = cr_compress_file(TEST_TEXT_FILE_XZ, dst_full_name,
                                      CR_CW_GZ_COMPRESSION, NULL, FALSE,
                                      &tmp_err);
     g_assert(!tmp_err);
     g_assert_cmpint(ret, ==, CRE_OK);
-    g_assert(g_file_test(copyfiletest->dst_file, G_FILE_TEST_IS_REGULAR));
+    g_assert(g_file_test(dst_full_name, G_FILE_TEST_IS_REGULAR));
 
     //assert content is readable after decompression and recompression
     char buf[30];
-    read_file(copyfiletest->dst_file, CR_CW_GZ_COMPRESSION, buf, 30);
+    read_file(dst_full_name, CR_CW_GZ_COMPRESSION, buf, 30);
     g_assert(g_strrstr(buf, "Lorem ipsum dolor sit amet"));
 
     g_assert(!tmp_err);
+    free(dst_full_name);
 }
 
 
@@ -672,13 +683,16 @@ compressfile_test_sqlite_file_gz_output(Copyfiletest *copyfiletest,
 {
     int ret;
     GError *tmp_err = NULL;
-    g_assert(!g_file_test(copyfiletest->dst_file, G_FILE_TEST_EXISTS));
-    ret = cr_compress_file(TEST_SQLITE_FILE, &copyfiletest->dst_file,
+
+    char * dst_full_name = g_strconcat(copyfiletest->dst_file, ".gz", NULL);
+
+    g_assert(!g_file_test(dst_full_name, G_FILE_TEST_EXISTS));
+    ret = cr_compress_file(TEST_SQLITE_FILE, dst_full_name,
                                      CR_CW_GZ_COMPRESSION, NULL, FALSE,
                                      &tmp_err);
     g_assert(!tmp_err);
     g_assert_cmpint(ret, ==, CRE_OK);
-    g_assert(g_file_test(copyfiletest->dst_file, G_FILE_TEST_IS_REGULAR));
+    g_assert(g_file_test(dst_full_name, G_FILE_TEST_EXISTS));
 
     g_assert(!tmp_err);
 }


### PR DESCRIPTION
In commit 79975df `in_dst` argument was changed to actually return allocated 
string with the final destination if the input `in_dst` was NULL, a direcotry or had
a different compression suffix. However the value is actually never used
anywhere and it is causing a memory leak.

This is a c API change but since we are reverting to previous IMO better API and 
before it was changed without problems I believe it is worth it.

The PR also contains a fix for suffix changes and one warning fix.