### PR TITLE
Add automated Github Actions CI

### DIFF
--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -1,0 +1,26 @@
+---
+name: Python CI
+on: [push, pull_request]
+
+jobs:
+  python-build:
+    name: Python Build
+    runs-on: ubuntu-latest
+    container: fedora:latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: |
+          sudo dnf -y install dnf-plugins-core
+          sudo dnf -y builddep createrepo_c.spec
+          pip install pytest scikit-build
+
+      - name: Compile
+        run: python3 setup.py bdist_wheel
+
+      - name: Install
+        run: pip install dist/*.whl
+
+      - name: Test
+        run: pytest --verbose --color=yes tests/python/tests/

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Modify createrepo_c.spec and run:
 
     utils/make_rpm.sh
 
-Note: [Current .spec for Fedora rawhide](http://pkgs.fedoraproject.org/cgit/createrepo_c.git/plain/createrepo_c.spec)
+Note: [Current .spec for Fedora rawhide](https://src.fedoraproject.org/rpms/createrepo_c/blob/master/f/createrepo_c.spec)
 
 ## Testing
 

--- a/createrepo_c.spec
+++ b/createrepo_c.spec
@@ -41,6 +41,7 @@ BuildRequires:  libxml2-devel
 BuildRequires:  openssl-devel
 BuildRequires:  rpm-devel >= 4.8.0-28
 BuildRequires:  sqlite-devel
+BuildRequires:  xz
 BuildRequires:  xz-devel
 BuildRequires:  zlib-devel
 %if %{with zchunk}


### PR DESCRIPTION
Add some automation for the following:

* Build createrepo_c + documentation + tests the "standard way" with the cmake workflows documented in the readme
* Build createrepo_c as a Python package, install it, and run the Python tests using pytest
* When a new release is tagged, automatically build and push the packages to PyPI
    * This would require a little bit of setup -- the RPM team or someone from the RPM team would need to be added as a co-maintainer on the createrepo_c Python package, and their credentials added to the "secrets" storage