### PR TITLE
CI: Add pip to packages Python CI installs

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -12,7 +12,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo dnf -y install dnf-plugins-core
+          sudo dnf -y install dnf-plugins-core python3-pip
           sudo dnf -y builddep createrepo_c.spec
           pip install --upgrade pip
           pip install pytest


### PR DESCRIPTION
python3-pip is just a weak dependence of python3. In case the python3
was installed without weakdeps in base container and did not get
upgraded during `dnf builddep`, the pip command is missing.