### PR TITLE
Fix conditionals in spec

### DIFF
--- a/createrepo_c.spec
+++ b/createrepo_c.spec
@@ -10,13 +10,13 @@
 %bcond_without drpm
 %endif
 
-%if 0%{?rhel} || 0%{?fedora} < 29
+%if 0%{?rhel}
 %bcond_with zchunk
 %else
 %bcond_without zchunk
 %endif
 
-%if 0%{?rhel} || 0%{?fedora} < 29
+%if 0%{?rhel} && 0%{?rhel} < 8
 %bcond_with libmodulemd
 %else
 %bcond_without libmodulemd


### PR DESCRIPTION
Enable libmodulemd in RHEL >= 8 (RhBug:1816753)

Fix case when 0%{?fedora} or 0%{?rhel} is undefined. For example, on
RHEL, 0%{?fedora} is undefined and "0%{?fedora} < 29" resolves to true,
although you'd expect it to be false.