### PR TITLE
Simplify checking for allowed modulemd metadata files

### DIFF
--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -88,30 +88,12 @@ allowed_file(const gchar *filename, GSList *exclude_masks)
 static gboolean
 allowed_modulemd_module_metadata_file(const gchar *filename)
 {
-    GError *tmp_err = NULL;
-    cr_CompressionType com_type = cr_detect_compression(filename, &tmp_err);
-    if (tmp_err) {
-        g_critical("Failed to detect compression for file %s: %s", filename, tmp_err->message);
-        g_clear_error(&tmp_err);
-        exit(EXIT_FAILURE);
-    }
-    const char *compression_suffix = cr_compression_suffix(com_type);
-    const char *allowed_arr[] = {".modulemd.yaml" , ".modulemd-defaults.yaml", "modules.yaml", '\0'};
-
-    for (const char **allowed = allowed_arr; allowed && *allowed; allowed++) {
-        if (compression_suffix) {
-            char allowed_with_suffix[40];
-            snprintf(allowed_with_suffix, sizeof allowed_with_suffix, "%s%s", *allowed, compression_suffix);
-            if (g_strrstr(filename, allowed_with_suffix)) {
-                return TRUE;
-            }
-        } else {
-            if (g_strrstr(filename, *allowed)) {
-                return TRUE;
-            }
-        }
-
-    }
+    if (g_strrstr(filename, "modules.yaml"))
+        return TRUE;
+    if (g_strrstr(filename, ".modulemd.yaml"))
+        return TRUE;
+    if (g_strrstr(filename, ".modulemd-defaults.yaml"))
+        return TRUE;
 
     return FALSE;
 }

--- a/src/mergerepo_c.c
+++ b/src/mergerepo_c.c
@@ -984,6 +984,7 @@ dump_merged_metadata(GHashTable *merged_hashtable,
         g_free(fil_xml_filename);
         g_free(oth_xml_filename);
         g_free(update_info_filename);
+        cr_xmlfile_close(fil_f, NULL);
         cr_xmlfile_close(pri_f, NULL);
         g_error_free(tmp_err);
         g_free(pri_dict);
@@ -1008,6 +1009,7 @@ dump_merged_metadata(GHashTable *merged_hashtable,
         g_free(fil_xml_filename);
         g_free(oth_xml_filename);
         g_free(update_info_filename);
+        cr_xmlfile_close(oth_f, NULL);
         cr_xmlfile_close(fil_f, NULL);
         cr_xmlfile_close(pri_f, NULL);
         g_error_free(tmp_err);

--- a/src/python/xml_dump-py.c
+++ b/src/python/xml_dump-py.c
@@ -62,6 +62,7 @@ py_xml_dump_filelists(G_GNUC_UNUSED PyObject *self, PyObject *args)
     xml = cr_xml_dump_filelists(Package_FromPyObject(py_pkg), &err);
     if (err) {
         nice_exception(&err, NULL);
+        free(xml);
         return NULL;
     }
 
@@ -83,6 +84,7 @@ py_xml_dump_other(G_GNUC_UNUSED PyObject *self, PyObject *args)
     xml = cr_xml_dump_other(Package_FromPyObject(py_pkg), &err);
     if (err) {
         nice_exception(&err, NULL);
+        free(xml);
         return NULL;
     }
 

--- a/src/repomd.c
+++ b/src/repomd.c
@@ -279,6 +279,7 @@ cr_repomd_record_fill(cr_RepomdRecord *md,
                 g_propagate_prefixed_error(err, tmp_err,
                     "Error while computing stat of compressed content of %s:",
                     path);
+                cr_contentstat_free(open_stat, NULL);
                 return code;
             }
             md->checksum_open_type = g_string_chunk_insert(md->chunk, checksum_str);

--- a/src/sqliterepo_c.c
+++ b/src/sqliterepo_c.c
@@ -762,6 +762,7 @@ generate_sqlite_from_xml(const gchar *path,
     if (!md_loc || !md_loc->repomd) {
         g_set_error(err, CREATEREPO_C_ERROR, CRE_NOFILE,
                     "repomd.xml doesn't exist");
+        cr_metadatalocation_free(md_loc);
         return FALSE;
     }
 

--- a/src/xml_file.c
+++ b/src/xml_file.c
@@ -389,6 +389,7 @@ cr_rewrite_header_package_count(gchar *original_filename,
         g_propagate_prefixed_error(err, tmp_err, "Error encountered while opening for writing:");
         cr_close(original_file, NULL); 
         g_free(tmp_xml_filename);
+        cr_xmlfile_close(new_file, NULL);
         return;
     }
 


### PR DESCRIPTION
Previous approach was too complicated, slow and ultimately unnecessary.
If an invalid file passes as allowed it is caught later when loading the
module metadata. There is no need to slow down checking of each
path/package with compression validation.

For: #275

I have also included a couple of memory leaks reported by covscans, 
these usually happen in error handling so they are not a big priority.