### PR TITLE
Fix additional covscan warnings

### DIFF
--- a/src/dumper_thread.c
+++ b/src/dumper_thread.c
@@ -562,7 +562,7 @@ cr_dumper_thread(gpointer data, gpointer user_data)
         //  * this isn't the last task
         // Then: save the task to the buffer
 
-        struct BufferedTask *buf_task = malloc(sizeof(struct BufferedTask));
+        struct BufferedTask *buf_task = g_malloc0(sizeof(struct BufferedTask));
         buf_task->id  = task->id;
         buf_task->res = res;
         buf_task->pkg = pkg;

--- a/src/misc.c
+++ b/src/misc.c
@@ -622,6 +622,12 @@ cr_decompress_file_with_stat(const char *src,
 
     if (!in_dst || g_str_has_suffix(in_dst, "/")) {
         char *filename = cr_get_filename(src);
+        if (!filename) {
+            g_debug("%s: Cannot get filename from: %s", __func__, src);
+            g_set_error(err, ERR_DOMAIN, CRE_NOFILE,
+                        "Cannot get filename from: %s", src);
+            return CRE_NOFILE;
+        }
         if (g_str_has_suffix(filename, c_suffix)) {
             filename = g_strndup(filename, strlen(filename) - strlen(c_suffix));
         } else {

--- a/src/xml_parser_filelists.c
+++ b/src/xml_parser_filelists.c
@@ -259,6 +259,11 @@ cr_end_handler(void *pdata, G_GNUC_UNUSED const xmlChar *element)
         cr_PackageFile *pkg_file = cr_package_file_new();
         pkg_file->name = cr_safe_string_chunk_insert(pd->pkg->chunk,
                                                 cr_get_filename(pd->content));
+        if (!pkg_file->name) {
+            g_set_error(&pd->err, ERR_DOMAIN, ERR_CODE_XML,
+                        "Invalid <file> element: %s", pd->content);
+            break;
+        }
         pd->content[pd->lcontent - strlen(pkg_file->name)] = '\0';
         pkg_file->path = cr_safe_string_chunk_insert_const(pd->pkg->chunk,
                                                            pd->content);

--- a/src/xml_parser_primary.c
+++ b/src/xml_parser_primary.c
@@ -633,6 +633,11 @@ cr_end_handler(void *pdata, G_GNUC_UNUSED const xmlChar *element)
         cr_PackageFile *pkg_file = cr_package_file_new();
         pkg_file->name = cr_safe_string_chunk_insert(pd->pkg->chunk,
                                                 cr_get_filename(pd->content));
+        if (!pkg_file->name) {
+            g_set_error(&pd->err, ERR_DOMAIN, ERR_CODE_XML,
+                        "Invalid <file> element: %s", pd->content);
+            break;
+        }
         pd->content[pd->lcontent - strlen(pkg_file->name)] = '\0';
         pkg_file->path = cr_safe_string_chunk_insert_const(pd->pkg->chunk,
                                                            pd->content);


### PR DESCRIPTION
Fixes defects reported for version: `createrepo_c-0.17.2-2.el9` compared to `createrepo_c-0.16.2-2.el9`.

- check we actually got a filename in xml parsers and in decompression
  function
- use g_malloc0 as we do in other places (it also takes care of checking
  if allocation was successful)