### PR TITLE
Default --keep-all-metadata to TRUE and add --discard-additional-metadata

### DIFF
--- a/doc/createrepo_c.8
+++ b/doc/createrepo_c.8
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH CREATEREPO_C 8 "2020-07-02" "" ""
+.TH CREATEREPO_C 8 "2021-09-23" "" ""
 .SH NAME
 createrepo_c \- Create rpm-md format (xml-rpm-metadata) repository
 .
@@ -173,7 +173,10 @@ Generate zchunk files as well as the standard repodata.
 Directory containing compression dictionaries for use by zchunk
 .SS \-\-keep\-all\-metadata
 .sp
-Keep all additional metadata (not primary, filelists and other xml or sqlite files, nor their compressed variants) from source repository during update.
+Keep all additional metadata (not primary, filelists and other xml or sqlite files, nor their compressed variants) from source repository during update (default).
+.SS \-\-discard\-additional\-metadata
+.sp
+Discard all additional metadata (not primary, filelists and other xml or sqlite files, nor their compressed variants) from source repository during update.
 .SS \-\-compatibility
 .sp
 Enforce maximal compatibility with classical createrepo (Affects only: \-\-retain\-old\-md).

--- a/src/cmd_parser.c
+++ b/src/cmd_parser.c
@@ -65,6 +65,8 @@ struct CmdOptions _cmd_options = {
         .zck_compression            = FALSE,
         .zck_dict_dir               = NULL,
         .recycle_pkglist            = FALSE,
+
+        .keep_all_metadata          = TRUE,
     };
 
 
@@ -168,6 +170,9 @@ static GOptionEntry cmd_entries[] =
 #endif
     { "keep-all-metadata", 0, 0, G_OPTION_ARG_NONE, &(_cmd_options.keep_all_metadata),
       "Keep all additional metadata (not primary, filelists and other xml or sqlite files, "
+      "nor their compressed variants) from source repository during update (default).", NULL },
+    { "discard-additional-metadata", 0, 0, G_OPTION_ARG_NONE, &(_cmd_options.discard_additional_metadata),
+      "Discard all additional metadata (not primary, filelists and other xml or sqlite files, "
       "nor their compressed variants) from source repository during update.", NULL },
     { "compatibility", 0, 0, G_OPTION_ARG_NONE, &(_cmd_options.compatibility),
       "Enforce maximal compatibility with classical createrepo (Affects only: --retain-old-md).", NULL },
@@ -510,9 +515,13 @@ check_arguments(struct CmdOptions *options,
         x++;
     }
 
-    // Check keep-all-metadata
-    if (options->keep_all_metadata && !options->update) {
-        g_warning("--keep-all-metadata has no effect (--update is not used)");
+    if (options->discard_additional_metadata) {
+        options->keep_all_metadata = FALSE;
+    }
+
+    // Check discard-additional-metadata
+    if (options->discard_additional_metadata && !options->update) {
+        g_warning("--discard-additional-metadata has no effect (--update is not used)");
     }
 
     // Process --distro tags

--- a/src/cmd_parser.h
+++ b/src/cmd_parser.h
@@ -77,6 +77,7 @@ struct CmdOptions {
     char *zck_dict_dir;         /*!< directory with zchunk dictionaries */
     gboolean keep_all_metadata; /*!< keep groupfile and updateinfo from source
                                      repo during update */
+    gboolean discard_additional_metadata; /*!< Inverse option to keep_all_metadata */
     gboolean ignore_lock;       /*!< Ignore existing .repodata/ - remove it,
                                      create the new one (empty) to serve as
                                      a lock and use a .repodata.date.pid for

--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -56,6 +56,7 @@
 #endif /* WITH_LIBMODULEMD */
 
 #define OUTDELTADIR "drpms/"
+#define DEFAULT_DATABASE_VERSION    10
 
 /** Check if the filename is excluded by any exclude mask.
  * @param filename      Filename (basename).
@@ -1611,6 +1612,11 @@ main(int argc, char **argv)
         pri_db_rec = cr_repomd_record_new("primary_db", pri_db_name);
         fil_db_rec = cr_repomd_record_new("filelists_db", fil_db_name);
         oth_db_rec = cr_repomd_record_new("other_db", oth_db_name);
+
+        // Set db version
+        pri_db_rec->db_ver = DEFAULT_DATABASE_VERSION;
+        fil_db_rec->db_ver = DEFAULT_DATABASE_VERSION;
+        oth_db_rec->db_ver = DEFAULT_DATABASE_VERSION;
 
         g_free(pri_db_name);
         g_free(fil_db_name);

--- a/src/locate_metadata.c
+++ b/src/locate_metadata.c
@@ -60,6 +60,10 @@ cr_metadatalocation_free(struct cr_MetadataLocation *ml)
         cr_remove_dir(ml->local_path, NULL);
     }
 
+    if (ml->repomd_data) {
+        cr_repomd_free(ml->repomd_data);
+    }
+
     g_free(ml->pri_xml_href);
     g_free(ml->fil_xml_href);
     g_free(ml->oth_xml_href);
@@ -146,6 +150,7 @@ cr_parse_repomd(const char *repomd_path,
     mdloc = g_malloc0(sizeof(struct cr_MetadataLocation));
     mdloc->repomd = g_strdup(repomd_path);
     mdloc->local_path = g_strdup(repopath);
+    mdloc->repomd_data = repomd;
 
     for (GSList *elem = repomd->records; elem; elem = g_slist_next(elem)) {
         cr_RepomdRecord *record = elem->data;
@@ -178,8 +183,6 @@ cr_parse_repomd(const char *repomd_path,
         } else
             g_free(full_location_href);
     }
-
-    cr_repomd_free(repomd);
 
     return mdloc;
 }

--- a/src/locate_metadata.h
+++ b/src/locate_metadata.h
@@ -21,6 +21,7 @@
 #define __C_CREATEREPOLIB_LOCATE_METADATA_H__
 
 #include <glib.h>
+#include "repomd.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -50,6 +51,7 @@ struct cr_MetadataLocation {
     int  tmp;                   /*!< if true - metadata were downloaded and
                                      will be removed during
                                      cr_metadata_location_free*/
+    cr_Repomd *repomd_data;     /*!< parsed repomd */
 };
 
 /** Structure representing additional metadata location and type.

--- a/src/repomd.c
+++ b/src/repomd.c
@@ -959,3 +959,143 @@ cr_repomd_sort_records(cr_Repomd *repomd)
 
     repomd->records = g_slist_sort(repomd->records, record_cmp);
 }
+
+
+gboolean cr_repomd_compare(cr_Repomd *repomd1, cr_Repomd *repomd2)
+{
+    if (!repomd1 || !repomd2) {
+        return FALSE;
+    }
+
+    // We don't want to compare revision (repomd1->revision), when the user
+    // doesn't specify any it is automatically filled with epoch timestamp,
+    // those would differ every time.
+
+    if (g_strcmp0(repomd1->contenthash, repomd2->contenthash)) {
+        return FALSE;
+    }
+    if (g_strcmp0(repomd1->contenthash_type, repomd2->contenthash_type)) {
+        return FALSE;
+    }
+
+    if (g_slist_length(repomd1->repo_tags) != g_slist_length(repomd2->repo_tags)) {
+        return FALSE;
+    }
+    gboolean found = FALSE;
+    for (GSList *elem1 = repomd1->repo_tags; elem1; elem1 = g_slist_next(elem1)) {
+        found = FALSE;
+        gchar *repo_tag1 = elem1->data;
+        for (GSList *elem2 = repomd2->repo_tags; elem2; elem2 = g_slist_next(elem2)) {
+            gchar *repo_tag2 = elem2->data;
+            if (!g_strcmp0(repo_tag1, repo_tag2)) {
+                found = TRUE;
+                break;
+            }
+        }
+
+        if (!found) {
+            return FALSE;
+        }
+    }
+
+    if (g_slist_length(repomd1->content_tags) != g_slist_length(repomd2->content_tags)) {
+        return FALSE;
+    }
+    for (GSList *elem1 = repomd1->content_tags; elem1; elem1 = g_slist_next(elem1)) {
+        found = FALSE;
+        gchar *content_tag1 = elem1->data;
+        for (GSList *elem2 = repomd2->content_tags; elem2; elem2 = g_slist_next(elem2)) {
+            gchar *content_tag2 = elem2->data;
+            if (!g_strcmp0(content_tag1, content_tag2)) {
+                found = TRUE;
+                break;
+            }
+        }
+
+        if (!found) {
+            return FALSE;
+        }
+    }
+
+    if (g_slist_length(repomd1->distro_tags) != g_slist_length(repomd2->distro_tags)) {
+        return FALSE;
+    }
+    for (GSList *elem1 = repomd1->distro_tags; elem1; elem1 = g_slist_next(elem1)) {
+        cr_DistroTag *distro_tag1 = elem1->data;
+        found = FALSE;
+        for (GSList *elem2 = repomd2->distro_tags; elem2; elem2 = g_slist_next(elem2)) {
+            cr_DistroTag *distro_tag2 = elem2->data;
+            if (!g_strcmp0(distro_tag1->cpeid, distro_tag2->cpeid) && !g_strcmp0(distro_tag1->val, distro_tag2->val)) {
+                found = TRUE;
+                break;
+            }
+        }
+
+        if (!found) {
+            return FALSE;
+        }
+    }
+
+    if (g_slist_length(repomd1->records) != g_slist_length(repomd2->records)) {
+        return FALSE;
+    }
+    for (GSList *elem1 = repomd1->records; elem1; elem1 = g_slist_next(elem1)) {
+        found = FALSE;
+        cr_RepomdRecord *record1 = elem1->data;
+        for (GSList *elem2 = repomd2->records; elem2; elem2 = g_slist_next(elem2)) {
+            cr_RepomdRecord *record2 = elem2->data;
+            if (g_strcmp0(record1->type, record2->type)) {
+                continue;
+            }
+            if (g_strcmp0(record1->location_href, record2->location_href)) {
+                continue;
+            }
+            if (g_strcmp0(record1->location_base, record2->location_base)) {
+                continue;
+            }
+            if (g_strcmp0(record1->checksum, record2->checksum)) {
+                continue;
+            }
+            if (g_strcmp0(record1->checksum_type, record2->checksum_type)) {
+                continue;
+            }
+            if (g_strcmp0(record1->checksum_open, record2->checksum_open)) {
+                continue;
+            }
+            if (g_strcmp0(record1->checksum_open_type, record2->checksum_open_type)) {
+                continue;
+            }
+            if (g_strcmp0(record1->checksum_header, record2->checksum_header)) {
+                continue;
+            }
+            if (g_strcmp0(record1->checksum_header_type, record2->checksum_header_type)) {
+                continue;
+            }
+
+            // We don't want to compare timestamps (record1->timestamp)
+            // or real location (record1->location_real)
+
+            if (record1->size != record2->size) {
+                continue;
+            }
+            if (record1->size_open != record2->size_open) {
+                continue;
+            }
+            if (record1->size_header != record2->size_header) {
+                continue;
+            }
+            if (record1->db_ver != record2->db_ver) {
+                continue;
+            }
+
+            found = TRUE;
+            break;
+        }
+
+        if (!found) {
+            return FALSE;
+        }
+    }
+
+    return TRUE;
+}

--- a/src/repomd.c
+++ b/src/repomd.c
@@ -38,7 +38,6 @@
 
 #define ERR_DOMAIN                  CREATEREPO_C_ERROR
 #define LOCATION_HREF_PREFIX        "repodata/"
-#define DEFAULT_DATABASE_VERSION    10
 #define BUFFER_SIZE                 8192
 
 cr_DistroTag *
@@ -329,11 +328,6 @@ cr_repomd_record_fill(cr_RepomdRecord *md,
             return CRE_STAT;
         }
     }
-
-    // Set db version
-
-    if (!md->db_ver)
-        md->db_ver = DEFAULT_DATABASE_VERSION;
 
     return CRE_OK;
 }

--- a/src/repomd_internal.h
+++ b/src/repomd_internal.h
@@ -29,6 +29,12 @@ extern "C" {
 
 cr_DistroTag *cr_distrotag_new();
 
+/** Compare two cr_Repomd objects to see if they match exactly
+ * @param repomd1                cr_Repomd object
+ * @param repomd2                cr_Repomd object
+ */
+gboolean cr_repomd_compare(cr_Repomd *repomd1, cr_Repomd *repomd2);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/python/tests/test_repomdrecord.py
+++ b/tests/python/tests/test_repomdrecord.py
@@ -102,7 +102,7 @@ class TestCaseRepomdRecord(unittest.TestCase):
         self.assertEqual(zrc.size, 269)
         self.assertEqual(zrc.size_open, 167)
         self.assertEqual(zrc.size_header, 132)
-        self.assertEqual(zrc.db_ver, 10)
+        self.assertEqual(zrc.db_ver, 0)
 
         zrc.rename_file()
 
@@ -132,7 +132,7 @@ class TestCaseRepomdRecord(unittest.TestCase):
         self.assertTrue(rec.timestamp > 0)
         self.assertEqual(rec.size, 134)
         self.assertEqual(rec.size_open, 167)
-        self.assertEqual(rec.db_ver, 10)
+        self.assertEqual(rec.db_ver, 0)
 
         # Set new values
 


### PR DESCRIPTION
= changelog =
msg: Switch default of --keep-all-metadata to TRUE and add --discard-additional-metadata
type: enhancement
resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1992209

`--keep-all-metadata` controls whether to keep additional metadata (such as comps, updateinfo, modules..) during a run with `--update`. With this PR they will be kept by default whereas before `--keep-all-metadata` had to be used.

We might want this because modular repositories really break without the `modules.yaml`.