### PR TITLE
Enable entity substitution when parsing xmls

### DIFF
--- a/src/xml_parser_filelists.c
+++ b/src/xml_parser_filelists.c
@@ -90,6 +90,9 @@ cr_start_handler(void *pdata, const xmlChar *element, const xmlChar **attr)
         return;
     }
 
+    gboolean free_attr = FALSE;
+    attr = unescape_ampersand_from_values(attr, &free_attr);
+
     // Update parser data
     pd->state      = sw->to;
     pd->docontent  = sw->docontent;
@@ -196,6 +199,10 @@ cr_start_handler(void *pdata, const xmlChar *element, const xmlChar **attr)
 
     default:
         break;
+    }
+
+    if (free_attr) {
+        g_strfreev((char **)attr);
     }
 }
 

--- a/src/xml_parser_internal.h
+++ b/src/xml_parser_internal.h
@@ -249,6 +249,15 @@ other_parser_data_new(cr_XmlParserNewPkgCb newpkgcb,
                       cr_XmlParserWarningCb warningcb,
                       void *warningcb_data);
 
+/** Replace &#38; by real ampersand char from values in attr.
+ * @param attr                   List of attributes
+ * @param allocation_needed      Output bool whether returned attr has to be freed.
+ * @return                       attr with regular '&' instead of "&#38";
+ */
+const xmlChar **unescape_ampersand_from_values(const xmlChar **attr,
+                                               gboolean *allocation_needed);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/xml_parser_other.c
+++ b/src/xml_parser_other.c
@@ -90,6 +90,9 @@ cr_start_handler(void *pdata, const xmlChar *element, const xmlChar **attr)
         return;
     }
 
+    gboolean free_attr = FALSE;
+    attr = unescape_ampersand_from_values(attr, &free_attr);
+
     // Update parser data
     pd->state      = sw->to;
     pd->docontent  = sw->docontent;
@@ -205,6 +208,10 @@ cr_start_handler(void *pdata, const xmlChar *element, const xmlChar **attr)
 
     default:
         break;
+    }
+
+    if (free_attr) {
+        g_strfreev((char **)attr);
     }
 }
 

--- a/src/xml_parser_primary.c
+++ b/src/xml_parser_primary.c
@@ -156,6 +156,9 @@ cr_start_handler(void *pdata, const xmlChar *element, const xmlChar **attr)
         return;
     }
 
+    gboolean free_attr = FALSE;
+    attr = unescape_ampersand_from_values(attr, &free_attr);
+
     // Update parser data
     pd->state      = sw->to;
     pd->docontent  = sw->docontent;
@@ -443,6 +446,10 @@ cr_start_handler(void *pdata, const xmlChar *element, const xmlChar **attr)
 
     default:
         break;
+    }
+
+    if (free_attr) {
+        g_strfreev((char **)attr);
     }
 }
 

--- a/src/xml_parser_repomd.c
+++ b/src/xml_parser_repomd.c
@@ -114,6 +114,9 @@ cr_start_handler(void *pdata, const xmlChar *element, const xmlChar **attr)
         return;
     }
 
+    gboolean free_attr = FALSE;
+    attr = unescape_ampersand_from_values(attr, &free_attr);
+
     // Update parser data
     pd->state      = sw->to;
     pd->docontent  = sw->docontent;
@@ -257,6 +260,10 @@ cr_start_handler(void *pdata, const xmlChar *element, const xmlChar **attr)
     case STATE_DBVERSION:
     default:
         break;
+    }
+
+    if (free_attr) {
+        g_strfreev((char **)attr);
     }
 }
 

--- a/src/xml_parser_updateinfo.c
+++ b/src/xml_parser_updateinfo.c
@@ -132,6 +132,9 @@ cr_start_handler(void *pdata, const xmlChar *element, const xmlChar **attr)
         return;
     }
 
+    gboolean free_attr = FALSE;
+    attr = unescape_ampersand_from_values(attr, &free_attr);
+
     // Update parser data
     pd->state      = sw->to;
     pd->docontent  = sw->docontent;
@@ -393,6 +396,10 @@ cr_start_handler(void *pdata, const xmlChar *element, const xmlChar **attr)
         assert(pd->updatecollectionpackage);
         package->relogin_suggested = TRUE;
         break;
+    }
+
+    if (free_attr) {
+        g_strfreev((char **)attr);
     }
 }
 

--- a/tests/python/tests/fixtures.py
+++ b/tests/python/tests/fixtures.py
@@ -27,6 +27,15 @@ OTHER_ERROR_00_PATH = os.path.join(MODIFIED_REPO_FILES_PATH,
 OTHER_MULTI_WARN_00_PATH = os.path.join(MODIFIED_REPO_FILES_PATH,
                            "multiple_warnings_00-other.xml")
 
+REPO_01_AMPERSAND_PRIMARY = os.path.join(MODIFIED_REPO_FILES_PATH,
+                                         "repo_01_ampersand-primary.xml")
+REPO_01_AMPERSAND_FILELISTS = os.path.join(MODIFIED_REPO_FILES_PATH,
+                                         "repo_01_ampersand-filelists.xml")
+REPO_01_AMPERSAND_OTHER = os.path.join(MODIFIED_REPO_FILES_PATH,
+                                         "repo_01_ampersand-other.xml")
+AMPERSAND_UPDATEINFO = os.path.join(MODIFIED_REPO_FILES_PATH,
+                                         "updateinfo_ampersand.xml")
+
 # Packages
 
 PKG_ARCHER = "Archer-3.4.5-6.x86_64.rpm"

--- a/tests/python/tests/test_xml_parser.py
+++ b/tests/python/tests/test_xml_parser.py
@@ -78,6 +78,81 @@ class TestCaseXmlParserPrimary(unittest.TestCase):
                 [(None, '/usr/bin/', 'super_kernel')])
         self.assertEqual(pkg.changelogs, [])
 
+    def test_xml_parser_primary_repo01_ampersand(self):
+
+        userdata = {
+                "pkgs": [],
+                "pkgcb_calls": 0,
+                "warnings": []
+            }
+
+        def newpkgcb(pkgId, name, arch):
+            pkg = cr.Package()
+            userdata["pkgs"].append(pkg)
+            return pkg
+
+        def pkgcb(pkg):
+            userdata["pkgcb_calls"] += 1
+
+        def warningcb(warn_type, msg):
+            userdata["warnings"].append((warn_type, msg))
+
+        cr.xml_parse_primary(REPO_01_AMPERSAND_PRIMARY, newpkgcb, pkgcb, warningcb, 1)
+
+        self.assertEqual([pkg.name for pkg in userdata["pkgs"]],
+            ['super_kernel'])
+        self.assertEqual(userdata["pkgcb_calls"], 1)
+        self.assertEqual(userdata["warnings"], [])
+
+        pkg = userdata["pkgs"][0]
+        self.assertEqual(pkg.pkgId, "152824bff2aa6d54f429d43e87a3ff3a0286505c6d93ec87692b5e3a9e3b97bf")
+        self.assertEqual(pkg.name, "super_kernel")
+        self.assertEqual(pkg.arch, "x86_64")
+        self.assertEqual(pkg.version, "6.0.1")
+        self.assertEqual(pkg.epoch, "0")
+        self.assertEqual(pkg.release, "2")
+        self.assertEqual(pkg.summary, "Tes&t package")
+        self.assertEqual(pkg.description, "This& package has provides, requires, obsoletes, conflicts options.")
+        self.assertEqual(pkg.url, "http://so_super_kernel.com/&it_is_awesome/yep_it_really_is")
+        self.assertEqual(pkg.time_file, 1334667003)
+        self.assertEqual(pkg.time_build, 1334667003)
+        self.assertEqual(pkg.rpm_license, "LGPL&v2")
+        self.assertEqual(pkg.rpm_vendor, None)
+        self.assertEqual(pkg.rpm_group, "Applications/S&ystem")
+        self.assertEqual(pkg.rpm_buildhost, "localhost.localdomain")
+        self.assertEqual(pkg.rpm_sourcerpm, "super_kernel&-6.0.1-2.src.rpm")
+        self.assertEqual(pkg.rpm_header_start, 280)
+        self.assertEqual(pkg.rpm_header_end, 2637)
+        self.assertEqual(pkg.rpm_packager, None)
+        self.assertEqual(pkg.size_package, 2845)
+        self.assertEqual(pkg.size_installed, 0)
+        self.assertEqual(pkg.size_archive, 404)
+        self.assertEqual(pkg.location_href, "super_kernel&-6.0.1-2.x86_64.rpm")
+        self.assertEqual(pkg.location_base, None)
+        self.assertEqual(pkg.checksum_type, "sha256")
+        self.assertEqual(pkg.requires,
+                [('bzip2', 'GE', '0', '1.0.0', None, True),
+                 ('expat', None, None, None, None, True),
+                 ('glib', 'GE', '0', '2.2&6.0', None, False),
+                 ('zlib', None, None, None, None, False)])
+        self.assertEqual(pkg.provides,
+                [('not_so_super_kernel', 'LT', '0', '5.8.0', None, False),
+                 ('super_kernel', 'EQ', '0', '6.0.0', None, False),
+                 ('supe&r_kernel', 'EQ', '0', '6.0.1', '2', False),
+                 ('super_&&kernel(x86-64)', 'EQ', '0', '6.0.1', '2', False)])
+        self.assertEqual(pkg.conflicts,
+                [('kernel', None, None, None, None, False),
+                 ('sup&er_kernel', 'EQ', '0', '5.0.0', None, False),
+                 ('super_kernel', 'LT', '0', '4.0.0', None, False)])
+        self.assertEqual(pkg.obsoletes,
+                [('kernel', None, None, None, None, False),
+                 ('super_kernel', 'EQ', '0', '5.9.0', None, False)])
+        self.assertEqual(pkg.files,
+                [(None, '/usr/bin&/', 'super_kernel'),
+                 (None, '/usr/bin/', 'supe&&r_kernel'),
+                 (None, '/usr/bin/', 'super_kernel')])
+        self.assertEqual(pkg.changelogs, [])
+
     def test_xml_parser_primary_snippet01(self):
 
         userdata = {
@@ -354,6 +429,67 @@ class TestCaseXmlParserFilelists(unittest.TestCase):
         self.assertEqual(pkg.obsoletes, [])
         self.assertEqual(pkg.files,
                 [(None, '/usr/bin/', 'super_kernel'),
+                 (None, '/usr/share/man/', 'super_kernel.8.gz')])
+        self.assertEqual(pkg.changelogs, [])
+
+    def test_xml_parser_filelists_repo01_ampersand(self):
+
+        userdata = {
+                "pkgs": [],
+                "pkgcb_calls": 0,
+                "warnings": []
+            }
+
+        def newpkgcb(pkgId, name, arch):
+            pkg = cr.Package()
+            userdata["pkgs"].append(pkg)
+            return pkg
+
+        def pkgcb(pkg):
+            userdata["pkgcb_calls"] += 1
+
+        def warningcb(warn_type, msg):
+            userdata["warnings"].append((warn_type, msg))
+
+        cr.xml_parse_filelists(REPO_01_AMPERSAND_FILELISTS, newpkgcb, pkgcb, warningcb)
+
+        self.assertEqual([pkg.name for pkg in userdata["pkgs"]],
+            ['super&_kernel'])
+        self.assertEqual(userdata["pkgcb_calls"], 1)
+        self.assertEqual(userdata["warnings"], [])
+
+        pkg = userdata["pkgs"][0]
+        self.assertEqual(pkg.pkgId, "152824bff2aa6d54f429d43e87a3ff3a0286505c6d93ec87692b5e3a9e3b97bf")
+        self.assertEqual(pkg.name, "super&_kernel")
+        self.assertEqual(pkg.arch, "x86_64")
+        self.assertEqual(pkg.version, "6.0.1")
+        self.assertEqual(pkg.epoch, "0")
+        self.assertEqual(pkg.release, "2")
+        self.assertEqual(pkg.summary, None)
+        self.assertEqual(pkg.description, None)
+        self.assertEqual(pkg.url, None)
+        self.assertEqual(pkg.time_file, 0)
+        self.assertEqual(pkg.time_build, 0)
+        self.assertEqual(pkg.rpm_license, None)
+        self.assertEqual(pkg.rpm_vendor, None)
+        self.assertEqual(pkg.rpm_group, None)
+        self.assertEqual(pkg.rpm_buildhost, None)
+        self.assertEqual(pkg.rpm_sourcerpm, None)
+        self.assertEqual(pkg.rpm_header_start, 0)
+        self.assertEqual(pkg.rpm_header_end, 0)
+        self.assertEqual(pkg.rpm_packager, None)
+        self.assertEqual(pkg.size_package, 0)
+        self.assertEqual(pkg.size_installed, 0)
+        self.assertEqual(pkg.size_archive, 0)
+        self.assertEqual(pkg.location_href, None)
+        self.assertEqual(pkg.location_base, None)
+        self.assertEqual(pkg.checksum_type, None)
+        self.assertEqual(pkg.requires, [])
+        self.assertEqual(pkg.provides, [])
+        self.assertEqual(pkg.conflicts, [])
+        self.assertEqual(pkg.obsoletes, [])
+        self.assertEqual(pkg.files,
+                [(None, '/usr/&&bin/', 'super_kernel'),
                  (None, '/usr/share/man/', 'super_kernel.8.gz')])
         self.assertEqual(pkg.changelogs, [])
 
@@ -660,6 +796,71 @@ class TestCaseXmlParserOther(unittest.TestCase):
                  ('Tomas Mlcoch <tmlcoch@redhat.com> - 6.0.1-2',
                    1334664001,
                    '- Second release')])
+
+    def test_xml_parser_other_repo01_ampersand(self):
+
+        userdata = {
+                "pkgs": [],
+                "pkgcb_calls": 0,
+                "warnings": []
+            }
+
+        def newpkgcb(pkgId, name, arch):
+            pkg = cr.Package()
+            userdata["pkgs"].append(pkg)
+            return pkg
+
+        def pkgcb(pkg):
+            userdata["pkgcb_calls"] += 1
+
+        def warningcb(warn_type, msg):
+            userdata["warnings"].append((warn_type, msg))
+
+        cr.xml_parse_other(REPO_01_AMPERSAND_OTHER, newpkgcb, pkgcb, warningcb)
+
+        self.assertEqual([pkg.name for pkg in userdata["pkgs"]],
+            ['super&_kernel'])
+        self.assertEqual(userdata["pkgcb_calls"], 1)
+        self.assertEqual(userdata["warnings"], [])
+
+        pkg = userdata["pkgs"][0]
+        self.assertEqual(pkg.pkgId, "152824bff2aa6d54f429d43e87a3ff3a0286505c6d93ec87692b5e3a9e3b97bf")
+        self.assertEqual(pkg.name, "super&_kernel")
+        self.assertEqual(pkg.arch, "x86_64")
+        self.assertEqual(pkg.version, "6.0.1")
+        self.assertEqual(pkg.epoch, "0")
+        self.assertEqual(pkg.release, "2")
+        self.assertEqual(pkg.summary, None)
+        self.assertEqual(pkg.description, None)
+        self.assertEqual(pkg.url, None)
+        self.assertEqual(pkg.time_file, 0)
+        self.assertEqual(pkg.time_build, 0)
+        self.assertEqual(pkg.rpm_license, None)
+        self.assertEqual(pkg.rpm_vendor, None)
+        self.assertEqual(pkg.rpm_group, None)
+        self.assertEqual(pkg.rpm_buildhost, None)
+        self.assertEqual(pkg.rpm_sourcerpm, None)
+        self.assertEqual(pkg.rpm_header_start, 0)
+        self.assertEqual(pkg.rpm_header_end, 0)
+        self.assertEqual(pkg.rpm_packager, None)
+        self.assertEqual(pkg.size_package, 0)
+        self.assertEqual(pkg.size_installed, 0)
+        self.assertEqual(pkg.size_archive, 0)
+        self.assertEqual(pkg.location_href, None)
+        self.assertEqual(pkg.location_base, None)
+        self.assertEqual(pkg.checksum_type, None)
+        self.assertEqual(pkg.requires, [])
+        self.assertEqual(pkg.provides, [])
+        self.assertEqual(pkg.conflicts, [])
+        self.assertEqual(pkg.obsoletes, [])
+        self.assertEqual(pkg.files, [])
+        self.assertEqual(pkg.changelogs,
+                [('Tomas Mlcoch <tml&coch@redhat.com> - 6.0.1-1',
+                   1334664000,
+                  '- Firs&t release'),
+                 ('Tomas Mlcoch <tmlcoch@redhat.com> - 6.0.1-2',
+                   1334664001,
+                   '- Second releas&e')])
 
     def test_xml_parser_other_snippet01(self):
 
@@ -1373,3 +1574,56 @@ class TestCaseXmlParserPkgIterator(unittest.TestCase):
 
         self.assertRaises(StopIteration, next, package_iterator)
         self.assertTrue(package_iterator.is_finished())
+
+class TestCaseXmlParserUpdateinfo(unittest.TestCase):
+    def test_xml_parser_updateinfo_ampersand(self):
+
+        userdata = {
+                "pkgs": [],
+                "pkgcb_calls": 0,
+                "warnings": []
+            }
+
+        def warningcb(warn_type, msg):
+            userdata["warnings"].append((warn_type, msg))
+
+        ui = cr.UpdateInfo()
+        cr.xml_parse_updateinfo(AMPERSAND_UPDATEINFO, ui, warningcb)
+
+        self.assertEqual(userdata["warnings"], [])
+
+        self.assertEqual(len(ui.updates), 1)
+        rec = ui.updates[0]
+
+        self.assertEqual(rec.fromstr, "se&cresponseteam@foo.bar")
+        self.assertEqual(rec.status, "final")
+        self.assertEqual(rec.type, "enhancement")
+        self.assertEqual(rec.version, "3")
+        self.assertEqual(rec.id, "foobarupd&ate_1")
+        self.assertEqual(rec.title, "title_1")
+        self.assertEqual(rec.rights, "rights_1&")
+        self.assertEqual(rec.release, "release_1&")
+        self.assertEqual(rec.pushcount, "pushcount_1")
+        self.assertEqual(rec.severity, "severity_1")
+        self.assertEqual(rec.summary, "summary_1")
+        self.assertEqual(rec.description, "description_1")
+        self.assertEqual(rec.solution, "solution_1&")
+        self.assertEqual(rec.reboot_suggested, True)
+        self.assertEqual(len(rec.references), 1)
+
+        ref = rec.references[0]
+        self.assertEqual(ref.href, "https://foo&bar/foobarupdate_1")
+        self.assertEqual(ref.id, "1")
+        self.assertEqual(ref.type, "self")
+        self.assertEqual(ref.title, "u&pdate_1")
+        self.assertEqual(len(rec.collections), 1)
+
+        col = rec.collections[0]
+        self.assertEqual(col.shortname, "f&oo.component")
+        self.assertEqual(col.name, "Foo component&")
+        self.assertEqual(len(col.packages), 1)
+
+        pkg = col.packages[0]
+        self.assertEqual(pkg.name, "ba&r")
+        self.assertEqual(pkg.src, "bar-2.0.1-3.src.rpm")
+        self.assertEqual(pkg.filename, "bar&-2.0.1-3.noarch.rpm")

--- a/tests/testdata/modified_repo_files/repo_01_ampersand-filelists.xml
+++ b/tests/testdata/modified_repo_files/repo_01_ampersand-filelists.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<filelists xmlns="http://linux.duke.edu/metadata/filelists" packages="1">
+<package pkgid="152824bff2aa6d54f429d43e87a3ff3a0286505c6d93ec87692b5e3a9e3b97bf" name="super&amp;_kernel" arch="x86_64">
+    <version epoch="0" ver="6.0.1" rel="2"/>
+
+    <file>/usr/&amp;&amp;bin/super_kernel</file>
+    <file>/usr/share/man/super_kernel.8.gz</file>
+</package>
+
+</filelists>

--- a/tests/testdata/modified_repo_files/repo_01_ampersand-other.xml
+++ b/tests/testdata/modified_repo_files/repo_01_ampersand-other.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<otherdata xmlns="http://linux.duke.edu/metadata/other" packages="1">
+<package pkgid="152824bff2aa6d54f429d43e87a3ff3a0286505c6d93ec87692b5e3a9e3b97bf" name="super&amp;_kernel" arch="x86_64">
+    <version epoch="0" ver="6.0.1" rel="2"/>
+
+<changelog author="Tomas Mlcoch &lt;tml&amp;coch@redhat.com&gt; - 6.0.1-1" date="1334664000">- Firs&amp;t release</changelog>
+<changelog author="Tomas Mlcoch &lt;tmlcoch@redhat.com&gt; - 6.0.1-2" date="1334664001">- Second releas&amp;e</changelog>
+
+</package>
+
+</otherdata>

--- a/tests/testdata/modified_repo_files/repo_01_ampersand-primary.xml
+++ b/tests/testdata/modified_repo_files/repo_01_ampersand-primary.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata xmlns="http://linux.duke.edu/metadata/common" xmlns:rpm="http://linux.duke.edu/metadata/rpm" packages="1">
+<package type="rpm">
+  <name>super_kernel</name>
+  <arch>x86_64</arch>
+  <version epoch="0" ver="6.0.1" rel="2"/>
+  <checksum type="sha256" pkgid="YES">152824bff2aa6d54f429d43e87a3ff3a0286505c6d93ec87692b5e3a9e3b97bf</checksum>
+  <summary>Tes&amp;t package</summary>
+  <description>This&amp; package has provides, requires, obsoletes, conflicts options.</description>
+  <packager></packager>
+  <url>http://so_super_kernel.com/&amp;it_is_awesome/yep_it_really_is</url>
+  <time file="1334667003" build="1334667003"/>
+  <size package="2845" installed="0" archive="404"/>
+<location href="super_kernel&amp;-6.0.1-2.x86_64.rpm"/>
+  <format>
+    <rpm:license>LGPL&amp;v2</rpm:license>
+    <rpm:vendor/>
+    <rpm:group>Applications/S&amp;ystem</rpm:group>
+    <rpm:buildhost>localhost.localdomain</rpm:buildhost>
+    <rpm:sourcerpm>super_kernel&amp;-6.0.1-2.src.rpm</rpm:sourcerpm>
+    <rpm:header-range start="280" end="2637"/>
+    <rpm:provides>
+      <rpm:entry name="not_so_super_kernel" flags="LT" epoch="0" ver="5.8.0"/>
+      <rpm:entry name="super_kernel" flags="EQ" epoch="0" ver="6.0.0"/>
+      <rpm:entry name="supe&amp;r_kernel" flags="EQ" epoch="0" ver="6.0.1" rel="2"/>
+      <rpm:entry name="super_&amp;&amp;kernel(x86-64)" flags="EQ" epoch="0" ver="6.0.1" rel="2"/>
+    </rpm:provides>
+    <rpm:requires>
+      <rpm:entry name="bzip2" flags="GE" epoch="0" ver="1.0.0" pre="1"/>
+      <rpm:entry name="expat" pre="1"/>
+      <rpm:entry name="glib" flags="GE" epoch="0" ver="2.2&amp;6.0"/>
+      <rpm:entry name="zlib"/>
+    </rpm:requires>
+    <rpm:conflicts>
+      <rpm:entry name="kernel"/>
+      <rpm:entry name="sup&amp;er_kernel" flags="EQ" epoch="0" ver="5.0.0"/>
+      <rpm:entry name="super_kernel" flags="LT" epoch="0" ver="4.0.0"/>
+    </rpm:conflicts>
+    <rpm:obsoletes>
+      <rpm:entry name="kernel"/>
+      <rpm:entry name="super_kernel" flags="EQ" epoch="0" ver="5.9.0"/>
+    </rpm:obsoletes>
+    <file>/usr/bin&amp;/super_kernel</file>
+    <file>/usr/bin/supe&amp;&amp;r_kernel</file>
+    <file>/usr/bin/super_kernel</file>
+  </format>
+</package>
+</metadata>

--- a/tests/testdata/modified_repo_files/updateinfo_ampersand.xml
+++ b/tests/testdata/modified_repo_files/updateinfo_ampersand.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<updates>
+  <update from="se&amp;cresponseteam@foo.bar" status="final" type="enhancement" version="3">
+    <id>foobarupd&amp;ate_1</id>
+    <title>title_1</title>
+    <issued date="2012-12-12 00:00:00"/>
+    <updated date="2012-12-12 00:00:00"/>
+    <rights>rights_1&amp;</rights>
+    <release>release_1&amp;</release>
+    <pushcount>pushcount_1</pushcount>
+    <severity>severity_1</severity>
+    <summary>summary_1</summary>
+    <description>description_1</description>
+    <solution>solution_1&amp;</solution>
+    <reboot_suggested>True</reboot_suggested>
+    <references>
+        <reference href="https://foo&amp;bar/foobarupdate_1" id="1" type="self" title="u&amp;pdate_1"/>
+    </references>
+    <pkglist>
+      <collection short="f&amp;oo.component">
+        <name>Foo component&amp;</name>
+        <package name="ba&amp;r" version="2.0.1" release="3" epoch="0" arch="noarch" src="bar-2.0.1-3.src.rpm">
+          <filename>bar&amp;-2.0.1-3.noarch.rpm</filename>
+          <sum type="sha256">29be985e1f652cd0a29ceed6a1c49964d3618bddd22f0be3292421c8777d26c8</sum>
+          <reboot_suggested/>
+          <restart_suggested/>
+          <relogin_suggested/>
+        </package>
+      </collection>
+    </pkglist>
+  </update>
+</updates>


### PR DESCRIPTION
Repodata don't use any custom entities but libxml2 enforces some in
order to have a valid xml document when saved (`<`, `>`, `&`,...)
http://xmlsoft.org/entities.html

When createrepo_c runs with `--update` it parses repodata which can
contain such entities (`&amp;` for `&`). We want to substitute them back
so when the data is used again it doesn't get re-escaped.

https://github.com/rpm-software-management/createrepo_c/issues/286