### PR TITLE
Use --error-exit-val option by default

### DIFF
--- a/doc/createrepo_c.8
+++ b/doc/createrepo_c.8
@@ -212,7 +212,7 @@ Append this prefix before location_href in output repodata
 Checksum type to be used in repomd.xml
 .SS \-\-error\-exit\-val
 .sp
-Exit with retval 2 if there were any errors during processing
+Exit with retval 2 if there were any errors during processing (option deprecated, on by default)
 .SS \-\-ignore\-lock
 .sp
 Expert (risky) option: Ignore an existing .repodata/. (Remove the existing .repodata/ and create an empty new one to serve as a lock for other createrepo instances. For the repodata generation, a different temporary dir with the name in format .repodata.time.microseconds.pid/ will be used). NOTE: Use this option on your own risk! If two createrepos run simultaneously, then the state of the generated metadata is not guaranteed \- it can be inconsistent and wrong.

--- a/src/cmd_parser.c
+++ b/src/cmd_parser.c
@@ -208,7 +208,7 @@ static GOptionEntry cmd_entries[] =
     { "repomd-checksum", 0, 0, G_OPTION_ARG_STRING, &(_cmd_options.repomd_checksum),
       "Checksum type to be used in repomd.xml", "CHECKSUM_TYPE"},
     { "error-exit-val", 0, 0, G_OPTION_ARG_NONE, &(_cmd_options.error_exit_val),
-      "Exit with retval 2 if there were any errors during processing", NULL },
+      "Exit with retval 2 if there were any errors during processing (option deprecated, on by default)", NULL },
     { "recycle-pkglist", 0, 0, G_OPTION_ARG_NONE, &(_cmd_options.recycle_pkglist),
       "Read the list of packages from old metadata directory and re-use it.  This "
       "option is only useful with --update (complements --pkglist and friends).",

--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -1307,7 +1307,7 @@ main(int argc, char **argv)
     g_thread_pool_free(pool, FALSE, TRUE);
 
     // if there were any errors, exit nonzero
-    if ( cmd_options->error_exit_val && user_data.had_errors ) {
+    if ( user_data.had_errors ) {
 	exit_val = 2;
     }
 


### PR DESCRIPTION
= changelog =
msg: Use --error-exit-val option by default
type: enhancement
resolves: https://github.com/rpm-software-management/createrepo_c/issues/302