### PR TITLE
Remove allow_out_of_order option and fix couple of leaks

### DIFF
--- a/examples/python/repodata_parsing.py
+++ b/examples/python/repodata_parsing.py
@@ -251,8 +251,7 @@ def third_method():
                                         other_xml_path,
                                         None,
                                         pkgcb,
-                                        warningcb,
-                                        False)
+                                        warningcb)
 
 if __name__ == "__main__":
     print('"All in one shot" method:')

--- a/src/python/xml_parser-py.c
+++ b/src/python/xml_parser-py.c
@@ -715,16 +715,15 @@ py_xml_parse_main_metadata_together(G_GNUC_UNUSED PyObject *self, PyObject *args
     char *primary_filename;
     char *filelists_filename;
     char *other_filename;
-    int allow_out_of_order = 1;
     PyObject *py_newpkgcb, *py_pkgcb, *py_warningcb;
     CbData cbdata;
     GError *tmp_err = NULL;
     static char *kwlist[] = { "primary", "filelists", "other", "newpkgcb", "pkgcb",
-                              "warningcb", "allow_out_of_order", NULL };
+                              "warningcb", NULL };
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "sssOOO|p:py_xml_parse_main_metadata_together", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "sssOOO:py_xml_parse_main_metadata_together", kwlist,
                                      &primary_filename, &filelists_filename, &other_filename, &py_newpkgcb,
-                                     &py_pkgcb, &py_warningcb, &allow_out_of_order)) {
+                                     &py_pkgcb, &py_warningcb )) {
         return NULL;
     }
 
@@ -777,7 +776,6 @@ py_xml_parse_main_metadata_together(G_GNUC_UNUSED PyObject *self, PyObject *args
                                         &cbdata,
                                         ptr_c_warningcb,
                                         &cbdata,
-                                        allow_out_of_order,
                                         &tmp_err);
 
     Py_XDECREF(py_newpkgcb);

--- a/src/xml_parser.h
+++ b/src/xml_parser.h
@@ -279,17 +279,21 @@ cr_xml_parse_updateinfo(const char *path,
                         GError **err);
 
 /** Parse all 3 main metadata types (primary, filelists and other) at the same time.
- * Once a package is fully parsed pkgcb is called which transfers ownership of the package
- * to the user, cr_xml_parse_main_metadata_together no longer needs it and it can be freed.
+ * Once a package is fully parsed pkgcb is called, if a cr_Package wasn't provided using
+ * newpkgcb new cr_Package is created and its ownership is transferred to the user by the
+ * pkgcb call.
  * This means we don't have store all the packages in memory at the same time, which
  * significantly reduces the memory footprint.
  * Input metadata files can be compressed.
+ * Metadata primary, filelists and other have to have the packages in the same order.
  * @param primary_path       Path to a primary xml file.
  * @param filelists_path     Path to a filelists xml file.
  * @param other_path         Path to an other xml file.
  * @param newpkgcb           Callback for a new package. Called when the new package
- *                           xml chunk is found and a package object to store
- *                           the data is needed.
+ *                           xml chunk is found and a package object to store the data
+ *                           is needed. If this callback is used, the user has full
+ *                           ownership of the package, it will not be freed if the
+ *                           parsing is interrupted or there is an error.
  * @param newpkgcb_data      User data for the newpkgcb.
  * @param pkgcb              Package callback. Called when a package is completely
  *                           parsed containing information from all 3 main metadata

--- a/src/xml_parser.h
+++ b/src/xml_parser.h
@@ -297,10 +297,6 @@ cr_xml_parse_updateinfo(const char *path,
  * @param pkgcb_data         User data for the pkgcb.
  * @param warningcb          Callback for warning messages.
  * @param warningcb_data     User data for the warningcb.
- * @param allow_out_of_order Whether we should allow different order of packages
- *                           among the main metadata files. If allowed, the more
- *                           the order varies the more memory we will need to
- *                           store all the started but unfinished packages.
  * @param err                GError **
  * @return                   cr_Error code.
  */
@@ -314,7 +310,6 @@ cr_xml_parse_main_metadata_together(const char *primary_path,
                                     void *pkgcb_data,
                                     cr_XmlParserWarningCb warningcb,
                                     void *warningcb_data,
-                                    gboolean allow_out_of_order,
                                     GError **err);
 
 /** @} */

--- a/src/xml_parser_main_metadata_together.c
+++ b/src/xml_parser_main_metadata_together.c
@@ -462,7 +462,11 @@ out:
     if (allow_out_of_order) {
         g_hash_table_destroy(cbdata.in_progress_pkgs_hash);
     } else {
-        cr_slist_free_full(cbdata.in_progress_pkgs_list, (GDestroyNotify) cr_package_free);
+        if (cbdata.newpkgcb) {
+            g_slist_free(cbdata.in_progress_pkgs_list);
+        } else {
+            cr_slist_free_full(cbdata.in_progress_pkgs_list, (GDestroyNotify) cr_package_free);
+        }
     }
 
     return ret;

--- a/src/xml_parser_main_metadata_together.c
+++ b/src/xml_parser_main_metadata_together.c
@@ -48,7 +48,7 @@ call_user_callback_if_package_finished(cr_Package *pkg, cr_CbData *cb_data, GErr
         (pkg->loadingflags & CR_PACKAGE_LOADED_FIL))
     {
         //remove first element in the list
-        cb_data->in_progress_pkgs_list = cb_data->in_progress_pkgs_list->next;
+        cb_data->in_progress_pkgs_list = g_slist_delete_link(cb_data->in_progress_pkgs_list, cb_data->in_progress_pkgs_list);
 
         // One package was fully finished
         cb_data->in_progress_count_primary--;

--- a/tests/python/tests/test_xml_parser.py
+++ b/tests/python/tests/test_xml_parser.py
@@ -1119,12 +1119,27 @@ class TestCaseXmlParserMainMetadataTogether(unittest.TestCase):
             return pkg
 
         self.assertRaises(cr.CreaterepoCError, cr.xml_parse_main_metadata_together,
-                          PRIMARY_ERROR_00_PATH, FILELISTS_ERROR_00_PATH,
-                          OTHER_ERROR_00_PATH, newpkgcb, None, None)
+                          PRIMARY_ERROR_00_PATH, REPO_02_FILXML,
+                          REPO_02_OTHXML, newpkgcb, None, None)
 
         # unlike parsing just primary, filelists or other separately when parsing together primary is parsed first fully
         # before newpkgcb is called so the error is detected before any user package is created
         self.assertEqual(len(userdata["pkgs"]), 0)
+
+        # test when the error is filelists
+        self.assertRaises(cr.CreaterepoCError, cr.xml_parse_main_metadata_together,
+                          REPO_02_PRIXML, FILELISTS_ERROR_00_PATH,
+                          REPO_02_OTHXML, newpkgcb, None, None)
+
+        self.assertEqual(len(userdata["pkgs"]), 2)
+
+        # test when the error is other
+        userdata = { "pkgs": [] }
+        self.assertRaises(cr.CreaterepoCError, cr.xml_parse_main_metadata_together,
+                          REPO_02_PRIXML, REPO_02_FILXML,
+                          OTHER_ERROR_00_PATH, newpkgcb, None, None)
+
+        self.assertEqual(len(userdata["pkgs"]), 2)
 
     def test_xml_parser_main_metadata_together_newpkgcb_abort(self):
         def newpkgcb(pkgId, name, arch):

--- a/tests/python/tests/test_xml_parser.py
+++ b/tests/python/tests/test_xml_parser.py
@@ -1049,8 +1049,7 @@ class TestCaseXmlParserMainMetadataTogether(unittest.TestCase):
         def warningcb(warn_type, msg):
             userdata["warnings"].append((warn_type, msg))
 
-        cr.xml_parse_main_metadata_together(REPO_02_PRIXML, REPO_02_FILXML, REPO_02_OTHXML, newpkgcb, pkgcb, warningcb,
-                                            allow_out_of_order=True)
+        cr.xml_parse_main_metadata_together(REPO_02_PRIXML, REPO_02_FILXML, REPO_02_OTHXML, newpkgcb, pkgcb, warningcb)
 
         self.assertEqual([pkg.name for pkg in userdata["pkgs"]],
             ['fake_bash', 'super_kernel'])

--- a/tests/test_xml_parser_main_metadata_together.c
+++ b/tests/test_xml_parser_main_metadata_together.c
@@ -127,7 +127,7 @@ test_cr_xml_parse_main_metadata_together_00(void)
     int parsed = 0;
     GError *tmp_err = NULL;
     int ret = cr_xml_parse_main_metadata_together(TEST_REPO_02_PRIMARY, TEST_REPO_02_FILELISTS, TEST_REPO_02_OTHER,
-                                                  NULL, NULL, pkgcb, &parsed, NULL, NULL, TRUE, &tmp_err);
+                                                  NULL, NULL, pkgcb, &parsed, NULL, NULL, &tmp_err);
     g_assert(tmp_err == NULL);
     g_assert_cmpint(ret, ==, CRE_OK);
     g_assert_cmpint(parsed, ==, 2);
@@ -141,16 +141,10 @@ test_cr_xml_parse_main_metadata_together_01_out_of_order_pkgs(void)
     int ret = cr_xml_parse_main_metadata_together(TEST_REPO_02_PRIMARY,
                                                   TEST_DIFF_ORDER_FILELISTS,
                                                   TEST_REPO_02_OTHER,
-                                                  NULL, NULL, pkgcb, &parsed, NULL, NULL, FALSE, &tmp_err);
+                                                  NULL, NULL, pkgcb, &parsed, NULL, NULL, &tmp_err);
     g_assert(tmp_err != NULL);
     g_assert_cmpint(ret, ==, CRE_XMLPARSER);
-
     g_clear_error(&tmp_err);
-    ret = cr_xml_parse_main_metadata_together(TEST_REPO_02_PRIMARY, TEST_DIFF_ORDER_FILELISTS, TEST_REPO_02_OTHER,
-                                              NULL, NULL, pkgcb, &parsed, NULL, NULL, TRUE, &tmp_err);
-    g_assert(tmp_err == NULL);
-    g_assert_cmpint(ret, ==, CRE_OK);
-    g_assert_cmpint(parsed, ==, 2);
 }
 
 static void
@@ -159,7 +153,7 @@ test_cr_xml_parse_main_metadata_together_02_invalid_path(void)
     int parsed = 0;
     GError *tmp_err = NULL;
     int ret = cr_xml_parse_main_metadata_together("/non/existent/file", TEST_REPO_02_FILELISTS, TEST_REPO_02_OTHER,
-                                                  NULL, NULL, pkgcb, &parsed, NULL, NULL, TRUE, &tmp_err);
+                                                  NULL, NULL, pkgcb, &parsed, NULL, NULL, &tmp_err);
     g_assert(tmp_err != NULL);
     g_assert_cmpint(ret, ==, CRE_NOFILE);
 }
@@ -170,24 +164,21 @@ test_cr_xml_parse_main_metadata_together_03_newpkgcb_returns_null(void)
     int parsed = 0;
     GError *tmp_err = NULL;
     int ret = cr_xml_parse_main_metadata_together(TEST_REPO_02_PRIMARY, TEST_REPO_02_FILELISTS, TEST_REPO_02_OTHER,
-                                                  newpkgcb_skip_fake_bash, NULL, pkgcb, &parsed, NULL, NULL, TRUE,
-                                                  &tmp_err);
+                                                  newpkgcb_skip_fake_bash, NULL, pkgcb, &parsed, NULL, NULL, &tmp_err);
     g_assert(tmp_err == NULL);
     g_assert_cmpint(ret, ==, CRE_OK);
     g_assert_cmpint(parsed, ==, 1);
 
     parsed = 0;
     ret = cr_xml_parse_main_metadata_together(TEST_REPO_02_PRIMARY, TEST_DIFF_ORDER_FILELISTS, TEST_REPO_02_OTHER,
-                                              newpkgcb_skip_fake_bash, NULL, pkgcb, &parsed, NULL, NULL, TRUE,
-                                              &tmp_err);
+                                              newpkgcb_skip_fake_bash, NULL, pkgcb, &parsed, NULL, NULL, &tmp_err);
     g_assert(tmp_err == NULL);
     g_assert_cmpint(ret, ==, CRE_OK);
     g_assert_cmpint(parsed, ==, 1);
 
     parsed = 0;
     ret = cr_xml_parse_main_metadata_together(TEST_REPO_02_PRIMARY, TEST_DIFF_ORDER_FILELISTS, TEST_REPO_02_OTHER,
-                                              newpkgcb_skip_fake_bash, NULL, pkgcb, &parsed, NULL, NULL, FALSE,
-                                              &tmp_err);
+                                              newpkgcb_skip_fake_bash, NULL, pkgcb, &parsed, NULL, NULL, &tmp_err);
     g_assert(tmp_err == NULL);
     g_assert_cmpint(ret, ==, CRE_OK);
     g_assert_cmpint(parsed, ==, 1);
@@ -199,7 +190,7 @@ test_cr_xml_parse_main_metadata_together_04_newpkgcb_interrupt(void)
     int parsed = 0;
     GError *tmp_err = NULL;
     int ret = cr_xml_parse_main_metadata_together(TEST_REPO_02_PRIMARY, TEST_REPO_02_FILELISTS, TEST_REPO_02_OTHER,
-                                                  newpkgcb_interrupt, &parsed, NULL, NULL, NULL, NULL, TRUE, &tmp_err);
+                                                  newpkgcb_interrupt, &parsed, NULL, NULL, NULL, NULL, &tmp_err);
     g_assert(tmp_err != NULL);
     g_error_free(tmp_err);
     g_assert_cmpint(ret, ==, CRE_CBINTERRUPTED);
@@ -212,7 +203,7 @@ test_cr_xml_parse_main_metadata_together_05_pkgcb_interrupt(void)
     int parsed = 0;
     GError *tmp_err = NULL;
     int ret = cr_xml_parse_main_metadata_together(TEST_REPO_02_PRIMARY, TEST_REPO_02_FILELISTS, TEST_REPO_02_OTHER,
-                                                  NULL, NULL, pkgcb_interrupt, &parsed, NULL, NULL, TRUE, &tmp_err);
+                                                  NULL, NULL, pkgcb_interrupt, &parsed, NULL, NULL, &tmp_err);
     g_assert(tmp_err != NULL);
     g_error_free(tmp_err);
     g_assert_cmpint(ret, ==, CRE_CBINTERRUPTED);
@@ -227,7 +218,7 @@ test_cr_xml_parse_main_metadata_together_06_warnings_bad_file_type(void)
     GError *tmp_err = NULL;
     GString *warn_strings = g_string_new(0);
     int ret = cr_xml_parse_main_metadata_together(TEST_REPO_02_PRIMARY, TEST_MRF_BAD_TYPE_FIL, TEST_REPO_02_OTHER,
-                                                  NULL, NULL, pkgcb, &parsed, warningcb, warn_strings, TRUE, &tmp_err);
+                                                  NULL, NULL, pkgcb, &parsed, warningcb, warn_strings, &tmp_err);
     g_assert(tmp_err == NULL);
     g_assert_cmpint(ret, ==, CRE_OK);
     g_assert_cmpint(parsed, ==, 2);
@@ -243,7 +234,7 @@ test_cr_xml_parse_main_metadata_together_07_warningcb_interrupt(void)
     GError *tmp_err = NULL;
     int ret = cr_xml_parse_main_metadata_together(TEST_REPO_02_PRIMARY, TEST_MRF_BAD_TYPE_FIL, TEST_REPO_02_OTHER,
                                                   NULL, NULL, pkgcb, NULL, warningcb_interrupt, &numofwarnings,
-                                                  TRUE, &tmp_err);
+                                                  &tmp_err);
     g_assert(tmp_err != NULL);
     g_error_free(tmp_err);
     g_assert_cmpint(ret, ==, CRE_CBINTERRUPTED);
@@ -256,7 +247,7 @@ test_cr_xml_parse_main_metadata_together_08_long_primary(void)
     int parsed = 0;
     GError *tmp_err = NULL;
     int ret = cr_xml_parse_main_metadata_together(TEST_LONG_PRIMARY, TEST_REPO_02_FILELISTS, TEST_REPO_02_OTHER,
-                                                  NULL, NULL, pkgcb, &parsed, NULL, NULL, TRUE, &tmp_err);
+                                                  NULL, NULL, pkgcb, &parsed, NULL, NULL, &tmp_err);
     g_assert(tmp_err == NULL);
     g_assert_cmpint(ret, ==, CRE_OK);
     g_assert_cmpint(parsed, ==, 2);


### PR DESCRIPTION
The option was causing issues when repository has duplicate packages and
it was providing little value. All repos should really have the same
order of packages in primary, filelists and other metadata.

For: https://github.com/rpm-software-management/createrepo_c/issues/305

It also includes 2 fixes for memory leaks originally from https://github.com/rpm-software-management/createrepo_c/pull/295