### PR TITLE
fix memory allocation in unescape_ampersand_from_values

### DIFF
--- a/src/xml_parser.c
+++ b/src/xml_parser.c
@@ -309,8 +309,8 @@ unescape_ampersand_from_values(const xmlChar **attr, gboolean *allocation_needed
     // we know which keys we want (they don't contain &) so
     // we don't have to check those.
     size_t nattr;
-    for (nattr = 1; attr[nattr]; nattr+=2) {
-        if (strchr((char *)attr[nattr], '&')) {
+    for (nattr = 0; attr[nattr]; nattr+=2) {
+        if (strchr((char *)attr[nattr+1], '&')) {
             *allocation_needed = TRUE;
         }
     }
@@ -319,7 +319,7 @@ unescape_ampersand_from_values(const xmlChar **attr, gboolean *allocation_needed
         return attr;
     }
 
-    char **attr_copy = g_malloc0(sizeof(char *) * (nattr - 1));
+    char **attr_copy = g_malloc0(sizeof(char *) * (nattr + 1));
     if (attr_copy) {
         for (nattr = 0; attr[nattr]; nattr++) {
             if (strchr((char *)attr[nattr], '&')) {


### PR DESCRIPTION
Without this patch testing after build fails with the following error message:

```[   38s] /home/abuild/rpmbuild/BUILD/createrepo_c-0.20.0/build/tests/python/tests/run_unittests.sh: line 1:  2327 Aborted                 LD_LIBRARY_PATH=/home/abuild/rpmbuild/BUILD/createrepo_c-0.20.0/build/src/: PYTHONPATH=/home/abuild/rpmbuild/BUILD/createrepo_c-0.20.0/build/src/python/ WITH_LIBMODULEMD=ON /usr/bin/python3 -m unittest discover -s /home/abuild/rpmbuild/BUILD/createrepo_c-0.20.0/tests/python/tests/../```

on openSUSE 15.3 and several other SUSE distros