### PR TITLE
Install header for createrepo_shared module

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,6 +40,7 @@ SET(headers
     constants.h
     mergerepo_c.h
     createrepo_c.h
+    createrepo_shared.h
     deltarpms.h
     error.h
     helpers.h

--- a/src/createrepo_shared.h
+++ b/src/createrepo_shared.h
@@ -120,13 +120,6 @@ cr_unset_cleanup_handler(GError **err);
 void
 cr_setup_logging(gboolean quiet, gboolean verbose);
 
-/**
- * Set global pointer to exit value that is used in function set by atexit
- * @param exit_val          Pointer to exit_value int
- */
-void
-cr_set_global_exit_value(int *exit_val);
-
 /** @} */
 
 #ifdef __cplusplus


### PR DESCRIPTION
This module contains some useful functions which are already documented in `createrepo_c`'s generated API documentation.