### PR TITLE
Update errno usage to fix incorrect GError messages

### DIFF
--- a/src/createrepo_shared.c
+++ b/src/createrepo_shared.c
@@ -230,11 +230,12 @@ cr_lock_repo(const gchar *repo_dir,
 
         // Try to create own - just as a lock
         if (g_mkdir(lock_dir, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)) {
+            const gchar * mkdir_error = g_strerror(errno);
             g_critical("(--ignore-lock enabled) Cannot create %s: %s",
-                       lock_dir, g_strerror(errno));
+                       lock_dir, mkdir_error);
             g_set_error(err, CREATEREPO_C_ERROR, CRE_IO,
                         "Cannot create: %s (--ignore-lock enabled): %s",
-                        lock_dir, g_strerror(errno));
+                        lock_dir, mkdir_error);
             return FALSE;
         } else {
             g_debug("(--ignore-lock enabled) Own and empty %s created "
@@ -249,11 +250,12 @@ cr_lock_repo(const gchar *repo_dir,
         tmp_repodata_dir = cr_append_pid_and_datetime(tmp, "/");
 
         if (g_mkdir(tmp_repodata_dir, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)) {
+            const gchar * mkdir_error = g_strerror(errno);
             g_critical("(--ignore-lock enabled) Cannot create %s: %s",
-                       tmp_repodata_dir, g_strerror(errno));
+                       tmp_repodata_dir, mkdir_error);
             g_set_error(err, CREATEREPO_C_ERROR, CRE_IO,
                         "Cannot create: %s (--ignore-lock enabled): %s",
-                        tmp_repodata_dir, g_strerror(errno));
+                        tmp_repodata_dir, mkdir_error);
             return FALSE;
         } else {
             g_debug("(--ignore-lock enabled) For data generation is used: %s",

--- a/src/dumper_thread.c
+++ b/src/dumper_thread.c
@@ -343,10 +343,11 @@ load_rpm(const char *fullpath,
     if (!stat_buf) {
         struct stat stat_buf_own;
         if (stat(fullpath, &stat_buf_own) == -1) {
+            const gchar * stat_error = g_strerror(errno);
             g_warning("%s: stat(%s) error (%s)", __func__,
-                      fullpath, g_strerror(errno));
+                      fullpath, stat_error);
             g_set_error(err,  CREATEREPO_C_ERROR, CRE_IO, "stat(%s) failed: %s",
-                        fullpath, g_strerror(errno));
+                        fullpath, stat_error);
             goto errexit;
         }
         pkg->time_file    = stat_buf_own.st_mtime;

--- a/src/misc.c
+++ b/src/misc.c
@@ -261,10 +261,11 @@ cr_get_header_byte_range(const char *filename, GError **err)
 
     FILE *fp = fopen(filename, "rb");
     if (!fp) {
+        const gchar * fopen_error = g_strerror(errno);
         g_debug("%s: Cannot open file %s (%s)", __func__, filename,
-                g_strerror(errno));
+                fopen_error);
         g_set_error(err, ERR_DOMAIN, CRE_IO,
-                    "Cannot open %s: %s", filename, g_strerror(errno));
+                    "Cannot open %s: %s", filename, fopen_error);
         return results;
     }
 
@@ -272,10 +273,10 @@ cr_get_header_byte_range(const char *filename, GError **err)
     // Get header range
 
     if (fseek(fp, 104, SEEK_SET) != 0) {
-        g_debug("%s: fseek fail on %s (%s)", __func__, filename,
-                g_strerror(errno));
+        const gchar * fseek_error = g_strerror(errno);
+        g_debug("%s: fseek fail on %s (%s)", __func__, filename, fseek_error);
         g_set_error(err, ERR_DOMAIN, CRE_IO,
-                    "Cannot seek over %s: %s", filename, g_strerror(errno));
+                    "Cannot seek over %s: %s", filename, fseek_error);
         fclose(fp);
         return results;
     }
@@ -406,19 +407,21 @@ cr_copy_file(const char *src, const char *in_dst, GError **err)
 
     // Open src file
     if ((orig = fopen(src, "rb")) == NULL) {
+        const gchar * fopen_error = g_strerror(errno);
         g_debug("%s: Cannot open source file %s (%s)", __func__, src,
-                g_strerror(errno));
+                fopen_error);
         g_set_error(err, ERR_DOMAIN, CRE_IO,
-                    "Cannot open file %s: %s", src, g_strerror(errno));
+                    "Cannot open file %s: %s", src, fopen_error);
         return FALSE;
     }
 
     // Open dst file
     if ((new = fopen(dst, "wb")) == NULL) {
+        const gchar * fopen_error = g_strerror(errno);
         g_debug("%s: Cannot open destination file %s (%s)", __func__, dst,
-                g_strerror(errno));
+                fopen_error);
         g_set_error(err, ERR_DOMAIN, CRE_IO,
-                    "Cannot open file %s: %s", dst, g_strerror(errno));
+                    "Cannot open file %s: %s", dst, fopen_error);
         return FALSE;
     }
 
@@ -431,10 +434,11 @@ cr_copy_file(const char *src, const char *in_dst, GError **err)
         }
 
         if (fwrite(buf, 1, readed, new) != readed) {
+            const gchar * fwrite_error = g_strerror(errno);
             g_debug("%s: Error while copy %s -> %s (%s)", __func__, src,
-                    dst, g_strerror(errno));
+                    dst, fwrite_error);
             g_set_error(err, ERR_DOMAIN, CRE_IO,
-                    "Error while write %s: %s", dst, g_strerror(errno));
+                    "Error while write %s: %s", dst, fwrite_error);
             return FALSE;
         }
     }
@@ -658,10 +662,11 @@ cr_decompress_file_with_stat(const char *src,
 
     new = fopen(dst, "wb");
     if (!new) {
+        const gchar * fopen_error = g_strerror(errno);
         g_debug("%s: Cannot open destination file %s (%s)",
-                __func__, dst, g_strerror(errno));
+                __func__, dst, fopen_error);
         g_set_error(err, ERR_DOMAIN, CRE_IO,
-                    "Cannot open %s: %s", src, g_strerror(errno));
+                    "Cannot open %s: %s", src, fopen_error);
         ret = CRE_IO;
         goto compress_file_cleanup;
     }
@@ -677,10 +682,11 @@ cr_decompress_file_with_stat(const char *src,
         }
 
         if (fwrite(buf, 1, readed, new) != (size_t) readed) {
+            const gchar * fwrite_error = g_strerror(errno);
             g_debug("%s: Error while copy %s -> %s (%s)",
-                    __func__, src, dst, g_strerror(errno));
+                    __func__, src, dst, fwrite_error);
             g_set_error(err, ERR_DOMAIN, CRE_IO,
-                        "Error while write %s: %s", dst, g_strerror(errno));
+                        "Error while write %s: %s", dst, fwrite_error);
             ret = CRE_IO;
             goto compress_file_cleanup;
         }

--- a/src/parsepkg.c
+++ b/src/parsepkg.c
@@ -92,10 +92,11 @@ read_header(const char *filename, Header *hdr, GError **err)
 
     FD_t fd = Fopen(filename, "r.ufdio");
     if (!fd) {
+        int fopen_error = errno;
         g_warning("%s: Fopen of %s failed %s",
-                  __func__, filename, g_strerror(errno));
+                  __func__, filename, g_strerror(fopen_error));
         g_set_error(err, ERR_DOMAIN, CRE_IO,
-                    "Fopen failed: %s", g_strerror(errno));
+                    "Fopen failed: %s", g_strerror(fopen_error));
         return FALSE;
     }
 
@@ -176,10 +177,11 @@ cr_package_from_rpm(const char *filename,
     if (!stat_buf) {
         struct stat stat_buf_own;
         if (stat(filename, &stat_buf_own) == -1) {
+            int stat_error = errno;
             g_warning("%s: stat(%s) error (%s)", __func__,
-                      filename, g_strerror(errno));
+                      filename, g_strerror(stat_error));
             g_set_error(err,  ERR_DOMAIN, CRE_IO, "stat(%s) failed: %s",
-                        filename, g_strerror(errno));
+                        filename, g_strerror(stat_error));
             goto errexit;
         }
         pkg->time_file    = stat_buf_own.st_mtime;


### PR DESCRIPTION
Either the call to `g_strerror` or the GLib logging calls have been changing the value of `errno` before it is used to set the error message in `g_set_error`. This resulted in a correct error message being logged, but an incorrect message being reported to the caller.

This change resolves the issue by calling `g_strerror(errno)` once and re-using the same message to pass to both the logging function and `g_set_error`.

Fixes: #320