### PR TITLE
createrepo_c shouldn't silently produce duplicate-NEVRA repos

### DIFF
--- a/src/dumper_thread.c
+++ b/src/dumper_thread.c
@@ -551,6 +551,19 @@ cr_dumper_thread(gpointer data, gpointer user_data)
     }
 #endif
 
+    // Allow checking that the same package (NEVRA) isn't present multiple times in the metadata
+    // Keep a hashtable of NEVRA mapped to an array-list of location_href values
+    g_mutex_lock(&(udata->mutex_nevra_table));
+    gchar *nevra = cr_package_nevra(pkg);
+    GArray *pkg_locations = g_hash_table_lookup(udata->nevra_table, nevra);
+    if (!pkg_locations) {
+        pkg_locations = g_array_new(FALSE, TRUE, sizeof(gchar *));
+        g_hash_table_insert(udata->nevra_table, nevra, pkg_locations);
+    }
+    gchar *location = g_strdup(pkg->location_href);
+    g_array_append_val(pkg_locations, location);
+    g_mutex_unlock(&(udata->mutex_nevra_table));
+
     // Buffering stuff
     g_mutex_lock(&(udata->mutex_buffer));
 

--- a/src/dumper_thread.h
+++ b/src/dumper_thread.h
@@ -69,6 +69,10 @@ struct UserData {
     long task_count;                // Total number of task to process
     long package_count;             // Total number of packages processed
 
+    // Duplicate package error checking
+    GMutex mutex_nevra_table;       // Mutex for the table of NEVRAs
+    GHashTable *nevra_table;         // Table of NEVRAs, with a list of location_href as key
+
     // Update stuff
     gboolean skip_stat;             // Skip stat() while updating
     cr_Metadata *old_metadata;      // Loaded metadata


### PR DESCRIPTION
Return an error code and print a message when more than one package have
the same NEVRA.

closes #307