### PR TITLE
Add --duplicated-nevra "keep-last" option, and --delayed-dump

### DIFF
--- a/src/cmd_parser.c
+++ b/src/cmd_parser.c
@@ -67,8 +67,27 @@ struct CmdOptions _cmd_options = {
         .recycle_pkglist            = FALSE,
 
         .keep_all_metadata          = TRUE,
+        .nevra_duplicates           = CR_ARG_DUP_NEVRA_KEEP_ALL,
     };
 
+
+gboolean
+duplicated_nevra_option_parser(const gchar *,
+                               const gchar *value,
+                               gpointer,
+                               GError **error)
+{
+    if (!g_strcmp0(value, "keep"))
+        _cmd_options.nevra_duplicates = CR_ARG_DUP_NEVRA_KEEP_ALL;
+    else if (!g_strcmp0(value, "keep-last"))
+        _cmd_options.nevra_duplicates = CR_ARG_DUP_NEVRA_KEEP_LAST;
+    else {
+        g_set_error(error, ERR_DOMAIN, CRE_BADARG,
+                    "Bad --duplicated-nevra argument, use 'keep' or 'keep-last'.");
+        return FALSE;
+    }
+    return TRUE;
+}
 
 
 // Command line params
@@ -213,6 +232,8 @@ static GOptionEntry cmd_entries[] =
       "Read the list of packages from old metadata directory and re-use it.  This "
       "option is only useful with --update (complements --pkglist and friends).",
       NULL },
+    { "duplicated-nevra", 0, 0, G_OPTION_ARG_CALLBACK, duplicated_nevra_option_parser,
+      "What to do about duplicates.", NULL, },
     { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL },
 };
 

--- a/src/cmd_parser.h
+++ b/src/cmd_parser.h
@@ -139,6 +139,9 @@ struct CmdOptions {
     GSList *modulemd_metadata;  /*!< paths to all modulemd metadata */
 
     gboolean recycle_pkglist;
+    gboolean delayed_dump;      /*!< Load _all_ the packages (parallel workers)
+                                     first, and then dump the database.  This
+                                     allows additional package filtering. */
 };
 
 /**

--- a/src/cmd_parser.h
+++ b/src/cmd_parser.h
@@ -26,6 +26,10 @@
 
 #define DEFAULT_CHANGELOG_LIMIT         10
 
+typedef enum {
+    CR_ARG_DUP_NEVRA_KEEP_ALL = 0,
+    CR_ARG_DUP_NEVRA_KEEP_LAST,
+} CmdDupNevra;
 
 /**
  * Command line options
@@ -142,6 +146,7 @@ struct CmdOptions {
     gboolean delayed_dump;      /*!< Load _all_ the packages (parallel workers)
                                      first, and then dump the database.  This
                                      allows additional package filtering. */
+    CmdDupNevra nevra_duplicates; /*!< What to do about duplicated NEVRA */
 };
 
 /**

--- a/src/dumper_thread.h
+++ b/src/dumper_thread.h
@@ -109,11 +109,19 @@ struct UserData {
 
     FILE *output_pkg_list;          // File where a list of read packages is written
     GMutex mutex_output_pkg_list;   // Mutex for output_pkg_list file
+    GArray *delayed_write;          // Dump these files once all packages are loaded
 };
 
 
 void
 cr_dumper_thread(gpointer data, gpointer user_data);
+
+
+void
+cr_delayed_dump_set(gpointer user_data);
+
+void
+cr_delayed_dump_run(gpointer user_data);
 
 /** @} */
 

--- a/src/dumper_thread.h
+++ b/src/dumper_thread.h
@@ -46,6 +46,11 @@ struct PoolTask {
     char* path;                     // Just path     - /foo/bar/packages
 };
 
+struct DuplicateLocation {
+    gchar *location;
+    cr_Package *pkg;
+};
+
 struct UserData {
     cr_XmlFile *pri_f;              // Opened compressed primary.xml.*
     cr_XmlFile *fil_f;              // Opened compressed filelists.xml.*
@@ -66,8 +71,9 @@ struct UserData {
     cr_ChecksumType checksum_type;  // Constant representing selected checksum
     const char *checksum_cachedir;  // Dir with cached checksums
     gboolean skip_symlinks;         // Skip symlinks
-    long task_count;                // Total number of task to process
+    long task_count;                // Total number of tasks to process
     long package_count;             // Total number of packages processed
+    long skipped_count;             // Total number of explicitly skipped packages
 
     // Duplicate package error checking
     GMutex mutex_nevra_table;       // Mutex for the table of NEVRAs

--- a/src/package.h
+++ b/src/package.h
@@ -135,6 +135,7 @@ typedef struct {
 
     cr_PackageLoadingFlags loadingflags; /*!<
         Bitfield flags with information about package loading  */
+    gboolean skip_dump;         /*!<  Don't dump this package to metadata. */
 } cr_Package;
 
 /** Create new (empty) dependency structure.

--- a/src/package.h
+++ b/src/package.h
@@ -40,7 +40,7 @@ typedef enum {
     CR_PACKAGE_LOADED_PRI   = (1<<10),  /*!< Primary metadata was loaded */
     CR_PACKAGE_LOADED_FIL   = (1<<11),  /*!< Filelists metadata was loaded */
     CR_PACKAGE_LOADED_OTH   = (1<<12),  /*!< Other metadata was loaded */
-    CR_PACKAGE_SINGLE_CHUNK = (1<<13),  /*!< Package uses single chunk */
+    CR_PACKAGE_SINGLE_CHUNK = (1<<13),  /*!< Package shares a single chunk with others */
 } cr_PackageLoadingFlags;
 
 /** Dependency (Provides, Conflicts, Obsoletes, Requires).

--- a/src/threads.c
+++ b/src/threads.c
@@ -131,7 +131,7 @@ cr_rewrite_pkg_count_thread(gpointer data, gpointer user_data)
     cr_rewrite_header_package_count(task->src,
                                     task->type,
                                     ud->package_count,
-                                    ud->task_count,
+                                    ud->task_count - ud->skipped_count,
                                     task->stat,
                                     task->zck_dict_dir,
                                     &tmp_err);


### PR DESCRIPTION
This is follow-up for #307.  Unfortunately, the parallel processing performance degrades a bit
with the "keep-last" option.

Motivation for Copr: https://pagure.io/copr/copr/issue/840

We can tweak this in the future (keep latest pkg per mtime, keep the first one, etc.).