### PR TITLE
Include <rpm/rpmstring.h> for rasprintf

### DIFF
--- a/src/xml_file.c
+++ b/src/xml_file.c
@@ -20,6 +20,7 @@
 #include <glib.h>
 #include <glib/gstdio.h>
 #include <assert.h>
+#include <rpm/rpmstring.h>
 #include "xml_file.h"
 #include <errno.h>
 #include "error.h"


### PR DESCRIPTION
Fixes build with Clang 16.

Bug: https://bugs.gentoo.org/875698
Signed-off-by: Sam James <sam@gentoo.org>