### PR TITLE
Revert "include rpm/rpmstring.h"

### DIFF
--- a/src/xml_file.c
+++ b/src/xml_file.c
@@ -19,7 +19,6 @@
 
 #include <glib.h>
 #include <glib/gstdio.h>
-#include <rpm/rpmstring.h>
 #include <assert.h>
 #include <rpm/rpmstring.h>
 #include "xml_file.h"


### PR DESCRIPTION
This reverts commit 696a7653c4c9c9ab8e0cd2e7e24dbda9ec51a2b8.

Already added by commit d8da644c45bec1429d600c619ce4e47af5906ef8.