### PR TITLE
BuildRequire python3-setuptools explicitly

### DIFF
--- a/createrepo_c.spec
+++ b/createrepo_c.spec
@@ -101,6 +101,7 @@ These development files are for easy manipulation with a repodata.
 Summary:        Python 3 bindings for the createrepo_c library
 %{?python_provide:%python_provide python3-%{name}}
 BuildRequires:  python3-devel
+BuildRequires:  python3-setuptools
 BuildRequires:  python3-sphinx
 Requires:       %{name}-libs = %{version}-%{release}
 


### PR DESCRIPTION
They are needed by utils/setup_for_python_metadata.py and/or pyproject.toml but were only transitively pulled in by sphinx -> babel -> setuptools.

Pull in downstream patch: https://src.fedoraproject.org/rpms/createrepo_c/pull-request/11#