### PR TITLE
Install distro packages instead of pip ones when available

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -17,8 +17,9 @@ jobs:
       run: |
         sudo dnf -y install dnf-plugins-core
         sudo dnf -y builddep createrepo_c.spec
+        sudo dnf -y install twine pytest
         pip install --upgrade pip
-        pip install twine pytest scikit-build
+        pip install scikit-build
 
     - name: Build Python sdist
       run: python3 setup.py sdist


### PR DESCRIPTION
Currently `Python Release` workflow fails due to conflicting request when a `Pygments` distro package is tried to be uninstalled when pip dependencies are being resolved. In this case we can install the dependencies from distro packages instead.