### PR TITLE
Correct 'doesn't exists' to 'doesn't exist' in several locations

### DIFF
--- a/src/cmd_parser.c
+++ b/src/cmd_parser.c
@@ -386,7 +386,7 @@ check_arguments(struct CmdOptions *options,
     // Check outputdir
     if (options->outputdir && !g_file_test(options->outputdir, G_FILE_TEST_EXISTS|G_FILE_TEST_IS_DIR)) {
         g_set_error(err, ERR_DOMAIN, CRE_BADARG,
-                    "Specified outputdir \"%s\" doesn't exists",
+                    "Specified outputdir \"%s\" doesn't exist",
                     options->outputdir);
         return FALSE;
     }
@@ -498,7 +498,7 @@ check_arguments(struct CmdOptions *options,
 
         if (!remote && !g_file_test(options->groupfile_fullpath, G_FILE_TEST_IS_REGULAR)) {
             g_set_error(err, ERR_DOMAIN, CRE_BADARG,
-                        "groupfile %s doesn't exists",
+                        "groupfile %s doesn't exist",
                         options->groupfile_fullpath);
             return FALSE;
         }
@@ -508,7 +508,7 @@ check_arguments(struct CmdOptions *options,
     if (options->pkglist) {
         if (!g_file_test(options->pkglist, G_FILE_TEST_IS_REGULAR)) {
             g_set_error(err, ERR_DOMAIN, CRE_BADARG,
-                        "pkglist file \"%s\" doesn't exists", options->pkglist);
+                        "pkglist file \"%s\" doesn't exist", options->pkglist);
             return FALSE;
         } else {
             char *content = NULL;

--- a/src/compression_wrapper.c
+++ b/src/compression_wrapper.c
@@ -127,10 +127,10 @@ cr_detect_compression(const char *filename, GError **err)
     assert(!err || *err == NULL);
 
     if (!g_file_test(filename, G_FILE_TEST_IS_REGULAR)) {
-        g_debug("%s: File %s doesn't exists or not a regular file",
+        g_debug("%s: File %s doesn't exist or not a regular file",
                 __func__, filename);
         g_set_error(err, ERR_DOMAIN, CRE_NOFILE,
-                    "File %s doesn't exists or not a regular file", filename);
+                    "File %s doesn't exist or not a regular file", filename);
         return CR_CW_UNKNOWN_COMPRESSION;
     }
 

--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -2475,7 +2475,7 @@ deltaerror:
     g_free(tmp_dirname);
 
     if (!cr_move_recursive(out_repo, old_repodata_path, &tmp_err)) {
-        g_debug("Old repodata doesn't exists: Cannot rename %s -> %s: %s",
+        g_debug("Old repodata doesn't exist: Cannot rename %s -> %s: %s",
                 out_repo, old_repodata_path, tmp_err->message);
     } else {
         g_debug("Renamed %s -> %s", out_repo, old_repodata_path);

--- a/src/createrepo_shared.h
+++ b/src/createrepo_shared.h
@@ -75,7 +75,7 @@ cr_unblock_terminating_signals(GError **err);
 /**
  * This function does:
  * - Tries to create repo/.repodata/ dir.
- * - If it doesn't exists, it's created and function returns TRUE.
+ * - If it doesn't exist, it's created and function returns TRUE.
  * - If it exists and ignore_lock is FALSE, returns FALSE and err is set.
  * - If it exists and ignore_lock is TRUE it:
  *  - Removes the existing .repodata/ dir and all its content

--- a/src/error.h
+++ b/src/error.h
@@ -41,7 +41,7 @@ typedef enum {
     CRE_NOFILE, /*!<
         (7) File doesn't exist */
     CRE_NODIR, /*!<
-        (8) Directory doesn't exist (not a dir or path doesn't exists) */
+        (8) Directory doesn't exist (not a dir or path doesn't exist) */
     CRE_EXISTS, /*!<
         (9) File/Directory already exists */
     CRE_UNKNOWNCHECKSUMTYPE, /*!<

--- a/src/locate_metadata.c
+++ b/src/locate_metadata.c
@@ -210,7 +210,7 @@ cr_get_local_metadata(const char *repopath, gboolean ignore_sqlite)
     // Create path to repomd.xml and check if it exists
     repomd = g_build_filename(repopath, "repodata", "repomd.xml", NULL);
     if (!g_file_test(repomd, G_FILE_TEST_EXISTS)) {
-        g_debug("%s: %s doesn't exists", __func__, repomd);
+        g_debug("%s: %s doesn't exist", __func__, repomd);
         return ret;
     }
 

--- a/src/mergerepo_c.c
+++ b/src/mergerepo_c.c
@@ -329,7 +329,7 @@ check_arguments(struct CmdOptions *options)
             ret = FALSE;
         }
         if (!g_file_test(options->blocked, G_FILE_TEST_EXISTS)) {
-            g_critical("File %s doesn't exists", options->blocked);
+            g_critical("File %s doesn't exist", options->blocked);
             ret = FALSE;
         }
     }

--- a/src/misc.h
+++ b/src/misc.h
@@ -547,7 +547,7 @@ cr_nevra_free(cr_NEVRA *nevra);
 /** Are the files identical?
  * Different paths could point to the same file.
  * This functions checks if both paths point to the same file or not.
- * If one of the files doesn't exists, the funcion doesn't fail
+ * If one of the files doesn't exist, the funcion doesn't fail
  * and just put FALSE into "indentical" value and returns.
  * @param fn1           First path
  * @param fn2           Second path

--- a/src/modifyrepo_c.c
+++ b/src/modifyrepo_c.c
@@ -218,7 +218,7 @@ cmd_options_to_task(GSList **modifyrepotasks,
 
     if (metadatapath && !g_file_test(metadatapath, G_FILE_TEST_IS_REGULAR)) {
         g_set_error(err, ERR_DOMAIN, CRE_ERROR,
-                    "File \"%s\" is not regular file or doesn't exists",
+                    "File \"%s\" is not regular file or doesn't exist",
                     metadatapath);
         return FALSE;
     }

--- a/src/modifyrepo_shared.c
+++ b/src/modifyrepo_shared.c
@@ -144,7 +144,7 @@ cr_modifyrepo(GSList *modifyrepotasks, gchar *repopath, GError **err)
     gchar *repomd_path = g_build_filename(repopath, "repomd.xml", NULL);
     if (!g_file_test(repomd_path, G_FILE_TEST_IS_REGULAR)) {
         g_set_error(err, ERR_DOMAIN, CRE_IO,
-                    "Regular file \"%s\" doesn't exists", repomd_path);
+                    "Regular file \"%s\" doesn't exist", repomd_path);
         g_free(repomd_path);
         return FALSE;
     }
@@ -241,7 +241,7 @@ cr_modifyrepo(GSList *modifyrepotasks, gchar *repopath, GError **err)
                 }
             }
 
-            // Check if record with this name doesn't exists yet
+            // Check if record with this name doesn't exist yet
             if (cr_repomd_get_record(repomd, task->type))
                 g_warning("Record with type \"%s\" already exists "
                           "in repomd.xml", task->type);

--- a/src/repomd.c
+++ b/src/repomd.c
@@ -125,7 +125,7 @@ cr_get_compressed_content_stat(const char *filename,
 
     if (!g_file_test(filename, G_FILE_TEST_IS_REGULAR)) {
         g_set_error(err, ERR_DOMAIN, CRE_NOFILE,
-                    "File %s doesn't exists or not a regular file", filename);
+                    "File %s doesn't exist or not a regular file", filename);
         return NULL;
     }
 
@@ -231,10 +231,10 @@ cr_repomd_record_fill(cr_RepomdRecord *md,
     checksum_t = checksum_type;
 
     if (!g_file_test(path, G_FILE_TEST_IS_REGULAR)) {
-        // File doesn't exists
-        g_warning("%s: File %s doesn't exists", __func__, path);
+        // File doesn't exist
+        g_warning("%s: File %s doesn't exist", __func__, path);
         g_set_error(err, ERR_DOMAIN, CRE_NOFILE,
-                    "File %s doesn't exists or not a regular file", path);
+                    "File %s doesn't exist or not a regular file", path);
         return CRE_NOFILE;
     }
 
@@ -370,10 +370,10 @@ cr_repomd_record_compress_and_fill(cr_RepomdRecord *record,
     }
 
     if (!g_file_test(record->location_real, G_FILE_TEST_IS_REGULAR)) {
-        // File doesn't exists
-        g_warning("%s: File %s doesn't exists", __func__, record->location_real);
+        // File doesn't exist
+        g_warning("%s: File %s doesn't exist", __func__, record->location_real);
         g_set_error(err, ERR_DOMAIN, CRE_NOFILE,
-                    "File %s doesn't exists or not a regular file",
+                    "File %s doesn't exist or not a regular file",
                     record->location_real);
         return CRE_NOFILE;;
     }

--- a/tests/python/tests/test_parsepkg.py
+++ b/tests/python/tests/test_parsepkg.py
@@ -39,7 +39,7 @@ class TestCaseParsepkg(unittest.TestCase):
 
         # Test error cases
 
-        # Rpm doesn't exists
+        # Rpm doesn't exist
         self.assertRaises(IOError, cr.package_from_rpm, "this_foo_pkg_should_not_exists.rpm")
 
         # Path is a directory, not a file
@@ -58,7 +58,7 @@ class TestCaseParsepkg(unittest.TestCase):
 
         # Test error cases
 
-        # Rpm doesn't exists
+        # Rpm doesn't exist
         self.assertRaises(IOError, cr.xml_from_rpm, "this_foo_pkg_should_not_exists.rpm")
 
         # Path is a directory, not a file

--- a/utils/speed_test.sh
+++ b/utils/speed_test.sh
@@ -45,7 +45,7 @@ fi
 REPO=$1
 
 if [ ! -d "$REPO" ]; then
-    echo "Directory $REPO doesn't exists"
+    echo "Directory $REPO doesn't exist"
     exit 1
 fi
 


### PR DESCRIPTION
Corrects a typo/mixed case in several locations, to fix #358 