### PR TITLE
src/cmd_parser.c: add a missing parameter name

### DIFF
--- a/src/cmd_parser.c
+++ b/src/cmd_parser.c
@@ -73,9 +73,9 @@ struct CmdOptions _cmd_options = {
 
 
 gboolean
-duplicated_nevra_option_parser(const gchar *,
+duplicated_nevra_option_parser(const gchar *option_name,
                                const gchar *value,
-                               gpointer,
+                               gpointer data,
                                GError **error)
 {
     if (!g_strcmp0(value, "keep"))


### PR DESCRIPTION
This resolves the following error with older versions of gcc: 
```
| /srv/storage/alex/yocto/build-32/tmp/work/x86_64-linux/createrepo-c-native/0.21.1-r0/git/src/cmd_parser.c: In function ‘duplicated_nevra_option_parser’: | /srv/storage/alex/yocto/build-32/tmp/work/x86_64-linux/createrepo-c-native/0.21.1-r0/git/src/cmd_parser.c:76:32: error: parameter name omitted
|    76 | duplicated_nevra_option_parser(const gchar *,
|       |                                ^~~~~~~~~~~~~
| /srv/storage/alex/yocto/build-32/tmp/work/x86_64-linux/createrepo-c-native/0.21.1-r0/git/src/cmd_parser.c:78:32: error: parameter name omitted
|    78 |                                gpointer,
|       |                                ^~~~~~~~
```