### PR TITLE
Fix some invalid C code to cover a wider ranger of compilers

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -116,7 +116,7 @@ static inline int cr_is_primary(const char *filename) {
     if (strstr(filename, "bin/"))
         return 1;
     return 0;
-};
+}
 
 /** Header range
  */

--- a/src/xml_dump_deltapackage.c
+++ b/src/xml_dump_deltapackage.c
@@ -134,7 +134,7 @@ cr_xml_dump_deltapackage(cr_DeltaPackage *package, GError **err)
     // First line in the buf is not indented, we must indent it by ourself
     result = g_malloc(sizeof(char *) * buf->use + INDENT + 1);
     for (int x = 0; x < INDENT; x++) result[x] = ' ';
-    memcpy((void *) result+INDENT, buf->content, buf->use);
+    memcpy(result+INDENT, buf->content, buf->use);
     result[buf->use + INDENT]   = '\n';
     result[buf->use + INDENT + 1]   = '\0';
 

--- a/src/xml_dump_updateinfo.c
+++ b/src/xml_dump_updateinfo.c
@@ -257,7 +257,7 @@ cr_xml_dump_updaterecord(cr_UpdateRecord *rec, GError **err)
     // First line in the buf is not indented, we must indent it by ourself
     result = g_malloc(sizeof(char *) * buf->use + INDENT + 1);
     for (int x = 0; x < INDENT; x++) result[x] = ' ';
-    memcpy((void *) result+INDENT, buf->content, buf->use);
+    memcpy(result+INDENT, buf->content, buf->use);
     result[buf->use + INDENT]   = '\n';
     result[buf->use + INDENT + 1]   = '\0';
 


### PR DESCRIPTION
Enabling more warnings and pedantic checking against ISO C17 conformance revealed some errors.  This patch just cleans up things to get the source compiling correctly under a wider range of gcc and clang versions.

Fixes: #357