### PR TITLE
Switch the default compression type to zstd

### DIFF
--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -884,9 +884,9 @@ main(int argc, char **argv)
     const char *xml_compression_suffix = NULL;
     const char *sqlite_compression_suffix = NULL;
     const char *compression_suffix = NULL;
-    cr_CompressionType xml_compression = CR_CW_GZ_COMPRESSION;
+    cr_CompressionType xml_compression = CR_CW_ZSTD_COMPRESSION;
     cr_CompressionType sqlite_compression = CR_CW_BZ2_COMPRESSION;
-    cr_CompressionType compression = CR_CW_GZ_COMPRESSION;
+    cr_CompressionType compression = CR_CW_ZSTD_COMPRESSION;
 
     if (cmd_options->compression_type != CR_CW_UNKNOWN_COMPRESSION) {
         sqlite_compression = cmd_options->compression_type;
@@ -1078,7 +1078,7 @@ main(int argc, char **argv)
     gchar *oth_xml_filename = NULL;
 
     g_message("Temporary output repo path: %s", tmp_out_repo);
-    g_debug("Creating .xml.gz files");
+    g_debug("Creating .xml.%s files", xml_compression_suffix);
 
     pri_xml_filename = g_strconcat(tmp_out_repo, "/primary.xml", xml_compression_suffix, NULL);
     fil_xml_filename = g_strconcat(tmp_out_repo, "/filelists.xml", xml_compression_suffix, NULL);

--- a/src/mergerepo_c.h
+++ b/src/mergerepo_c.h
@@ -28,7 +28,7 @@ extern "C" {
 #include "compression_wrapper.h"
 
 #define DEFAULT_DB_COMPRESSION_TYPE             CR_CW_BZ2_COMPRESSION
-#define DEFAULT_GROUPFILE_COMPRESSION_TYPE      CR_CW_GZ_COMPRESSION
+#define DEFAULT_COMPRESSION_TYPE                CR_CW_ZSTD_COMPRESSION
 
 typedef enum {
     MM_DEFAULT,
@@ -83,7 +83,7 @@ struct CmdOptions {
     GSList *repo_list;
     GSList *arch_list;
     cr_CompressionType db_compression_type;
-    cr_CompressionType groupfile_compression_type;
+    cr_CompressionType compression_type;
     MergeMethod merge_method;
 };
 

--- a/src/modifyrepo_shared.c
+++ b/src/modifyrepo_shared.c
@@ -31,7 +31,7 @@
 #include "xml_dump.h"
 
 #define ERR_DOMAIN              CREATEREPO_C_ERROR
-#define DEFAULT_COMPRESSION     CR_CW_GZ_COMPRESSION
+#define DEFAULT_COMPRESSION     CR_CW_ZSTD_COMPRESSION
 #define DEFAULT_CHECKSUM        CR_CHECKSUM_SHA256
 
 cr_ModifyRepoTask *


### PR DESCRIPTION
It also changes mergerepo_c so that option `--compress-type` sets compression for all repository files (except sqlite dbs).

Tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1311

Compression for sqlite dbs remains the same.

This is part of: https://fedoraproject.org/wiki/Changes/createrepo_c_1.0.0