### PR TITLE
Disable drpm support on fedora >= 39 (RhBug:2213212)

### DIFF
--- a/createrepo_c.spec
+++ b/createrepo_c.spec
@@ -4,7 +4,7 @@
 
 %global bash_completion %{_datadir}/bash-completion/completions/*
 
-%if 0%{?rhel} && ( 0%{?rhel} <= 7 || 0%{?rhel} >= 9 )
+%if ( 0%{?rhel} && ( 0%{?rhel} <= 7 || 0%{?rhel} >= 9 ) ) || ( 0%{?fedora} && 0%{?fedora} >= 39 )
 %bcond_with drpm
 %else
 %bcond_without drpm


### PR DESCRIPTION
Disable drpm support on fedora >= 39

RhBug: https://bugzilla.redhat.com/show_bug.cgi?id=2213212