### PR TITLE
mergerepo_c: create only one groupfile metadata

### DIFF
--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -847,25 +847,7 @@ main(int argc, char **argv)
 
     // Groupfile specified as argument
     if (cmd_options->groupfile_fullpath) {
-        gchar *compressed_path;
-        cr_CompressionType old_type = cr_detect_compression(cmd_options->groupfile_fullpath, &tmp_err);
-        if (tmp_err) {
-            compressed_path = g_strconcat(tmp_out_repo, cr_get_filename(cmd_options->groupfile_fullpath), compression_suffix, NULL);
-            g_debug("Unable to detect compression type of %s, using %s for groupfile.", cmd_options->groupfile_fullpath, compressed_path);
-            g_clear_error(&tmp_err);
-        } else if (old_type == CR_CW_NO_COMPRESSION) {
-            compressed_path = g_strconcat(tmp_out_repo, cr_get_filename(cmd_options->groupfile_fullpath), compression_suffix, NULL);
-        } else {
-            // strip compression suffix
-            _cleanup_free_ gchar *tmp_file = g_strndup(cmd_options->groupfile_fullpath, strlen(cmd_options->groupfile_fullpath) - strlen(cr_compression_suffix(old_type)));
-            compressed_path = g_strconcat(tmp_out_repo, cr_get_filename(tmp_file), compression_suffix, NULL);
-        }
-        if (cr_compress_file(cmd_options->groupfile_fullpath, compressed_path, compression, NULL, NULL, &tmp_err) != CRE_OK) {
-            g_critical("Cannot compress file: %s: %s", cmd_options->groupfile_fullpath,
-                       (tmp_err ? tmp_err->message : "Unknown error"));
-            g_clear_error(&tmp_err);
-            exit(EXIT_FAILURE);
-        }
+        gchar *compressed_path = cr_compress_groupfile(cmd_options->groupfile_fullpath, tmp_out_repo, compression);
         cr_Metadatum *new_groupfile_metadatum = g_malloc0(sizeof(cr_Metadatum));
         new_groupfile_metadatum->name = compressed_path;
         new_groupfile_metadatum->type = g_strdup("group");

--- a/src/metadata_internal.h
+++ b/src/metadata_internal.h
@@ -46,6 +46,17 @@ cr_metadata_load_modulemd(ModulemdModuleIndex **moduleindex,
                           gchar *path_to_md,
                           GError **err);
 
+/** Compress groupfile into dest_dir with specified compression.
+ * @param groupfile     Path to local groupfile, it can be already compressed by
+ *                      some compression.
+ * @param dest_dir      Path to directory where the compressed groupfile should be stored.
+ * @return              Path to the new compressed groupfile. Has to be freed by the caller.
+ */
+gchar *
+cr_compress_groupfile(const char *groupfile,
+                      const char *dest_dir,
+                      cr_CompressionType compression);
+
 
 #endif /* WITH_LIBMODULEMD */
 


### PR DESCRIPTION
We no longer create uncompressed groupfile. There is only one compressed
groupfile with type "group" (in repomd.xml). Therefore we don't need to copy the groupfile, compressing it
is enough.
Follow up for change in createrepo_c: https://github.com/rpm-software-management/createrepo_c/pull/373

This is for: https://fedoraproject.org/wiki/Changes/createrepo_c_1.0.0

Test: https://github.com/rpm-software-management/ci-dnf-stack/pull/1340

(This was causing a test fail in `ci-dnf-stack`)