### PR TITLE
Adjust printf formats for 64bit time_t on 32bit systems

### DIFF
--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -582,9 +582,9 @@ duplicates_warning(const char *nevra, GArray *locations, CmdDupNevra option)
   for (size_t i=0; i<locations->len; i++) {
       struct DuplicateLocation location = g_array_index(locations, struct
                                                         DuplicateLocation, i);
-      g_warning("    Sourced from location: \'%s\', build timestamp: %ld%s",
+      g_warning("    Sourced from location: \'%s\', build timestamp: %jd%s",
                 location.location,
-                location.pkg->time_build,
+                (intmax_t) location.pkg->time_build,
                 location.pkg->skip_dump ? skip_reason : "");
 
   }

--- a/src/misc.c
+++ b/src/misc.c
@@ -1512,11 +1512,11 @@ cr_append_pid_and_datetime(const char *str, const char *suffix)
     gettimeofday(&tv, NULL);
     timeinfo = localtime (&(tv.tv_sec));
     strftime(datetime, 80, "%Y%m%d%H%M%S", timeinfo);
-    gchar *result = g_strdup_printf("%s%jd.%s.%ld%s",
+    gchar *result = g_strdup_printf("%s%jd.%s.%jd%s",
                                     str ? str : "",
                                     (intmax_t) getpid(),
                                     datetime,
-                                    tv.tv_usec,
+                                    (intmax_t) tv.tv_usec,
                                     suffix ? suffix : "");
     return result;
 }

--- a/src/xml_dump_repomd.c
+++ b/src/xml_dump_repomd.c
@@ -143,7 +143,7 @@ cr_xml_dump_repomd_body(xmlNodePtr root, cr_Repomd *repomd)
                            BAD_CAST repomd->revision);
     } else {
         // Use the current time if no revision was explicitly specified
-        gchar *rev = g_strdup_printf("%ld", time(NULL));
+        gchar *rev = g_strdup_printf("%jd", (intmax_t) time(NULL));
         xmlNewChild(root, NULL, BAD_CAST "revision", BAD_CAST rev);
         g_free(rev);
     }


### PR DESCRIPTION
This fixes a crash when time_t is 64bit and also
fL::wqixes format specifier mismatch warnings as well while here

e.g.
warning: format '%ld' expects argument of type 'long int', but argument 2 has type 'time_t'