### PR TITLE
When compiled without zstd switch default compression back to gz

### DIFF
--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -826,9 +826,14 @@ main(int argc, char **argv)
     const char *xml_compression_suffix = NULL;
     const char *sqlite_compression_suffix = NULL;
     const char *compression_suffix = NULL;
-    cr_CompressionType xml_compression = CR_CW_ZSTD_COMPRESSION;
     cr_CompressionType sqlite_compression = CR_CW_BZ2_COMPRESSION;
+#ifdef WITH_ZSTD
+    cr_CompressionType xml_compression = CR_CW_ZSTD_COMPRESSION;
     cr_CompressionType compression = CR_CW_ZSTD_COMPRESSION;
+#else
+    cr_CompressionType xml_compression = CR_CW_GZ_COMPRESSION;
+    cr_CompressionType compression = CR_CW_GZ_COMPRESSION;
+#endif // WITH_ZSTD
 
     if (cmd_options->compression_type != CR_CW_UNKNOWN_COMPRESSION) {
         sqlite_compression = cmd_options->compression_type;

--- a/src/mergerepo_c.h
+++ b/src/mergerepo_c.h
@@ -28,7 +28,11 @@ extern "C" {
 #include "compression_wrapper.h"
 
 #define DEFAULT_DB_COMPRESSION_TYPE             CR_CW_BZ2_COMPRESSION
+#ifdef WITH_ZSTD
 #define DEFAULT_COMPRESSION_TYPE                CR_CW_ZSTD_COMPRESSION
+#else
+#define DEFAULT_COMPRESSION_TYPE                CR_CW_GZ_COMPRESSION
+#endif // WITH_ZSTD
 
 typedef enum {
     MM_DEFAULT,

--- a/src/modifyrepo_shared.c
+++ b/src/modifyrepo_shared.c
@@ -31,7 +31,11 @@
 #include "xml_dump.h"
 
 #define ERR_DOMAIN              CREATEREPO_C_ERROR
+#ifdef WITH_ZSTD
 #define DEFAULT_COMPRESSION     CR_CW_ZSTD_COMPRESSION
+#else
+#define DEFAULT_COMPRESSION     CR_CW_GZ_COMPRESSION
+#endif // WITH_ZSTD
 #define DEFAULT_CHECKSUM        CR_CHECKSUM_SHA256
 
 cr_ModifyRepoTask *


### PR DESCRIPTION
Without this change when compiled without zstd normal run ends in an error because of missing zstd.

Other approach could be to not allow building without zstd.