### PR TITLE
Detect need for _XOPEN_SOURCE for nftw() in CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,6 +61,23 @@ SET(headers
     koji.h
     xml_parser.h)
 
+# glibc needs _XOPEN_SOURCE >= 500 defined in order to expose nftw(),
+# other systems do not need this macro defined.  If necessary, set the
+# macro to 700 since that's the 7th revision which is what the Python
+# pieces will want.
+INCLUDE (CheckSymbolExists)
+CHECK_SYMBOL_EXISTS(nftw ftw.h HAVE_NFTW)
+IF (NOT HAVE_NFTW)
+    LIST(APPEND CMAKE_REQUIRED_DEFINITIONS -D_XOPEN_SOURCE=700)
+    CHECK_SYMBOL_EXISTS(nftw ftw.h HAVE_NFTW_XOPEN)
+
+    IF (HAVE_NFTW_XOPEN)
+        ADD_COMPILE_DEFINITIONS(_XOPEN_SOURCE=700)
+    ELSE ()
+        ERROR("unable to find nftw() definition")
+    ENDIF ()
+ENDIF ()
+
 IF (BUILD_LIBCREATEREPO_C_SHARED)
   SET (createrepo_c_library_type SHARED)
 ELSE ()

--- a/src/misc.c
+++ b/src/misc.c
@@ -17,8 +17,6 @@
  * USA.
  */
 
-#define _XOPEN_SOURCE 500
-
 #include <glib/gstdio.h>
 #include <glib.h>
 #include <gio/gio.h>


### PR DESCRIPTION
Some systems (e.g., glibc Linux systems) required _XOPEN_SOURCE be set to >= 500 in order to expose the nftw() function.  Other systems, such as macOS, do not require this definition.  When using feature macros like this, it is better to not define them explicitly in source code but rather define them dynamically at build configuration time based on what the build system presents.

This patch removes the explicit definiton of _XOPEN_SOURCE from src/misc.c and adds a block to src/CMakeLists.txt to determine if _XOPEN_SOURCE must be defined in order to use nftw().  If it is required, I set it to 700 which is what is required for the Python code as well and it avoids a redefinition warning.

Fixes: #374