### PR TITLE
Add `sanitizers` build option, fix bunch of detected problems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,12 @@ if (WITH_ZSTD)
     SET (CMAKE_C_FLAGS_DEBUG    "${CMAKE_C_FLAGS_DEBUG} -DWITH_ZSTD")
 endif()
 
+if (WITH_SANITIZERS)
+    message(WARNING "Building with sanitizers enabled!")
+    add_compile_options(-fsanitize=address -fsanitize=undefined -fsanitize=leak)
+    link_libraries(asan ubsan)
+endif()
+
 # Threaded XZ Compression
 # Note: This option is disabled by default, because Createrepo_c
 # parallelize a lot of tasks (including compression) by default, this

--- a/createrepo_c.spec
+++ b/createrepo_c.spec
@@ -31,6 +31,8 @@
 %bcond_with legacy_hashes
 %endif
 
+%bcond_with sanitizers
+
 Summary:        Creates a common metadata repository
 Name:           createrepo_c
 Version:        1.0.0
@@ -75,6 +77,12 @@ BuildRequires:  drpm-devel >= 0.4.0
 %endif
 %if %{with zstd}
 BuildRequires:  pkgconfig(libzstd)
+%endif
+
+%if %{with sanitizers}
+BuildRequires:  libasan
+BuildRequires:  liblsan
+BuildRequires:  libubsan
 %endif
 
 %if 0%{?fedora} || 0%{?rhel} > 7
@@ -127,7 +135,8 @@ pushd build-py3
       -DWITH_LIBMODULEMD=%{?with_libmodulemd:ON}%{!?with_libmodulemd:OFF} \
       -DWITH_LEGACY_HASHES=%{?with_legacy_hashes:ON}%{!?with_legacy_hashes:OFF} \
       -DENABLE_DRPM=%{?with_drpm:ON}%{!?with_drpm:OFF} \
-      -DWITH_ZSTD=%{?with_zstd:ON}%{!?with_zstd:OFF}
+      -DWITH_ZSTD=%{?with_zstd:ON}%{!?with_zstd:OFF} \
+      -DWITH_SANITIZERS=%{?with_sanitizers:ON}%{!?with_sanitizers:OFF}
   make %{?_smp_mflags} RPM_OPT_FLAGS="%{optflags}"
   # Build C documentation
   make doc-c

--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -907,6 +907,7 @@ main(int argc, char **argv)
                     GSList *next_inner = g_slist_next(element_iter);
                     gchar *path_to_found_md = (gchar *) element_iter->data;
                     if (!g_strcmp0(path_to_found_md, m->name)) {
+                        g_free(path_to_found_md);
                         cmd_options->modulemd_metadata = g_slist_delete_link(
                             cmd_options->modulemd_metadata, element_iter);
                     }

--- a/src/deltarpms.c
+++ b/src/deltarpms.c
@@ -130,6 +130,7 @@ cr_deltapackage_from_drpm_base(const char *filename,
 
     deltapackage->nevr = cr_safe_string_chunk_insert_null(
                                     deltapackage->chunk, str);
+    free(str);
 
     ret = drpm_get_string(delta, DRPM_TAG_SEQUENCE, &str);
     if (ret != DRPM_ERR_OK) {
@@ -141,6 +142,7 @@ cr_deltapackage_from_drpm_base(const char *filename,
 
     deltapackage->sequence = cr_safe_string_chunk_insert_null(
                                     deltapackage->chunk, str);
+    free(str);
 
     drpm_destroy(&delta);
 
@@ -328,7 +330,8 @@ cr_delta_thread(gpointer data, gpointer udata)
             cr_DeltaTargetPackage *old = lelem->data;
 
             g_debug("Generating delta %s -> %s", old->path, tpkg->path);
-            cr_drpm_create(old, tpkg, user_data->outdeltadir, &tmp_err);
+            char * drpm_path = cr_drpm_create(old, tpkg, user_data->outdeltadir, &tmp_err);
+            free(drpm_path);
             if (tmp_err) {
                 g_warning("Cannot generate delta %s -> %s : %s",
                           old->path, tpkg->path, tmp_err->message);
@@ -338,6 +341,8 @@ cr_delta_thread(gpointer data, gpointer udata)
             if (++x == user_data->num_deltas)
                 break;
         }
+
+        g_slist_free_full(local_candidates, (GDestroyNotify) cr_deltatargetpackage_free);
     }
 
     g_debug("Deltas for \"%s\" (%"G_GINT64_FORMAT") generated",

--- a/src/dumper_thread.c
+++ b/src/dumper_thread.c
@@ -704,6 +704,8 @@ cr_dumper_thread(gpointer data, gpointer user_data)
     if (!pkg_locations) {
         pkg_locations = g_array_new(FALSE, TRUE, sizeof(struct DuplicateLocation));
         g_hash_table_insert(udata->nevra_table, nevra, pkg_locations);
+    } else {
+        g_free(nevra);
     }
 
     struct DuplicateLocation location;

--- a/src/dumper_thread.h
+++ b/src/dumper_thread.h
@@ -81,7 +81,7 @@ struct UserData {
 
     // Duplicate package error checking
     GMutex mutex_nevra_table;       // Mutex for the table of NEVRAs
-    GHashTable *nevra_table;         // Table of NEVRAs, with a list of location_href as key
+    GHashTable *nevra_table;        // Table of NEVRAs mapped to packages and their locations
 
     // Update stuff
     gboolean skip_stat;             // Skip stat() while updating

--- a/src/misc.c
+++ b/src/misc.c
@@ -866,8 +866,15 @@ gboolean
 cr_move_recursive(const char *srcDir, const char *dstDir, GError **err)
 {
     if (rename(srcDir, dstDir) == -1) {
-        if (!cr_gio_cp(g_file_new_for_path(srcDir), g_file_new_for_path(dstDir), G_FILE_COPY_ALL_METADATA, NULL, err))
+        GFile * gsrcDir = g_file_new_for_path(srcDir);
+        GFile * gdstDir = g_file_new_for_path(dstDir);
+        if (!cr_gio_cp(gsrcDir, gdstDir, G_FILE_COPY_ALL_METADATA, NULL, err)) {
+            g_object_unref(gsrcDir);
+            g_object_unref(gdstDir);
             return FALSE;
+        }
+        g_object_unref(gsrcDir);
+        g_object_unref(gdstDir);
         return (cr_remove_dir(srcDir, err) == CRE_OK);
     }
     return TRUE;
@@ -1081,6 +1088,7 @@ cr_split_rpm_filename(const char *filename)
             g_free(str);
             str = filename_epoch[0];
             epoch = filename_epoch[1];
+            g_free(filename_epoch);
         } else {
             g_strfreev(filename_epoch);
         }
@@ -1239,6 +1247,7 @@ cr_str_to_nevra(const char *instr)
             epoch = epoch_candidate;
             g_free(str);
             str = nvra_epoch[0];
+            g_free(nvra_epoch);
         } else {
             g_strfreev(nvra_epoch);
         }

--- a/src/sqliterepo_c.c
+++ b/src/sqliterepo_c.c
@@ -725,8 +725,6 @@ generate_sqlite_from_xml(const gchar *path,
     // Set other paths
     in_repo         = g_build_filename(in_dir, "repodata/", NULL);
     out_dir         = g_strdup(in_dir);
-    lock_dir        = g_build_filename(out_dir, ".repodata/", NULL);
-    tmp_out_repo    = g_build_filename(out_dir, ".repodata/", NULL);
 
     // Block signals that terminates the process
     if (!cr_block_terminating_signals(err))

--- a/src/sqliterepo_c.c
+++ b/src/sqliterepo_c.c
@@ -102,6 +102,9 @@ sqliterepocmdoptions_free(SqliterepoCmdOptions *options)
 CR_DEFINE_CLEANUP_FUNCTION0(SqliterepoCmdOptions*, cr_local_sqliterepocmdoptions_free, sqliterepocmdoptions_free)
 #define _cleanup_sqliterepocmdoptions_free_ __attribute__ ((cleanup(cr_local_sqliterepocmdoptions_free)))
 
+CR_DEFINE_CLEANUP_FUNCTION0(cr_Repomd*, cr_local_repomd_free, cr_repomd_free)
+#define _cleanup_repomd_free_ __attribute__ ((cleanup(cr_local_repomd_free)))
+
 /**
  * Parse commandline arguments for sqliterepo utility
  */
@@ -769,7 +772,7 @@ generate_sqlite_from_xml(const gchar *path,
 
     // Parse repomd.xml
     int rc;
-    cr_Repomd *repomd = cr_repomd_new();
+    _cleanup_repomd_free_ cr_Repomd *repomd = cr_repomd_new();
 
     rc = cr_xml_parse_repomd(repomd_path,
                              repomd,
@@ -967,7 +970,6 @@ generate_sqlite_from_xml(const gchar *path,
     g_rmdir(tmp_out_repo);
 
     // Clean up
-    cr_repomd_free(repomd);
     cr_repomd_record_free(pri_db_rec);
     cr_repomd_record_free(fil_db_rec);
     cr_repomd_record_free(oth_db_rec);

--- a/src/xml_file.c
+++ b/src/xml_file.c
@@ -414,11 +414,13 @@ cr_rewrite_header_package_count(gchar *original_filename,
             size_t zck_dict_size = 0;
             if (g_file_get_contents(zck_dict_file, &zck_dict, &zck_dict_size, &tmp_err)){
                 cr_set_dict(new_file->f, zck_dict, zck_dict_size, &tmp_err);
+                g_free(zck_dict);
             } else {
                 g_propagate_prefixed_error(err, tmp_err, "Error encountered setting zck dict:");
                 cr_xmlfile_close(new_file, NULL);
                 cr_close(original_file, NULL);
                 g_free(tmp_xml_filename);
+                g_free(zck_dict);
                 return;
             }
         }

--- a/tests/test_compression_wrapper.c
+++ b/tests/test_compression_wrapper.c
@@ -900,7 +900,7 @@ test_cr_get_zchunk_with_index(void)
     g_assert(!tmp_err);
 
     g_assert_cmpint(cr_get_zchunk_with_index(f, 1, &output, &tmp_err), ==, 56);
-    g_assert(g_str_has_prefix(output, "foobar foobar foobar"));
+    g_assert(!strncmp(output, "foobar foobar foobar", 20));
     g_free(output);
     g_assert(!tmp_err);
 

--- a/tests/test_koji.c
+++ b/tests/test_koji.c
@@ -258,8 +258,10 @@ test_koji_allowed_pkg_included(void)
     g_assert(koji_allowed(pkg, koji_stuff));
 
     g_assert_cmpint(g_hash_table_size(koji_stuff->seen_rpms), ==, 1);
-    g_assert(g_hash_table_contains(koji_stuff->seen_rpms, cr_package_nvra(pkg)));
+    gchar * nvra = cr_package_nvra(pkg);
+    g_assert(g_hash_table_contains(koji_stuff->seen_rpms, nvra));
 
+    g_free(nvra);
     koji_stuff_destroy(&koji_stuff);
     cr_package_free(pkg);
 }

--- a/tests/test_load_metadata.c
+++ b/tests/test_load_metadata.c
@@ -187,6 +187,8 @@ static void test_cr_metadata_locate_and_load_modulemd(void)
     g_assert_nonnull (modulemd_module_index_get_module (
                       cr_metadata_modulemd(metadata),
                       "testmodule"));
+
+    cr_metadata_free(metadata);
 }
 #endif /* WITH_LIBMODULEMD */
 

--- a/tests/test_locate_metadata.c
+++ b/tests/test_locate_metadata.c
@@ -199,6 +199,7 @@ static void test_cr_parse_repomd(void)
     g_assert_cmpstr(TEST_REPO_00_PRIMARY, ==, ret->pri_xml_href);
     g_assert_cmpstr(TEST_REPO_00_OTHER, ==, ret->oth_xml_href);
     g_assert_cmpstr(TEST_REPO_00_FILELISTS, ==, ret->fil_xml_href);
+    cr_metadatalocation_free(ret);
 }
 
 static void test_cr_parse_repomd_with_additional_metadata(void)
@@ -235,7 +236,7 @@ static void test_cr_parse_repomd_with_additional_metadata(void)
     metadatum = g_slist_find_custom(ret->additional_metadata, "updateinfo_zck", cr_cmp_metadatum_type)->data;
     g_assert(metadatum);
 
-    g_slist_free_full(ret->additional_metadata, (GDestroyNotify) cr_metadatum_free);
+    cr_metadatalocation_free(ret);
 }
 
 int main(int argc, char *argv[])

--- a/tests/test_misc.c
+++ b/tests/test_misc.c
@@ -388,8 +388,9 @@ test_cr_get_filename(void)
 }
 
 
+// Read from the file maximum of buffer_len-1 bytes and add terminating zero.
 static int
-read_file(char *f, cr_CompressionType compression, char* buffer, int amount)
+read_file(char *f, cr_CompressionType compression, char* buffer, int buffer_len)
 {
     int ret = CRE_OK;
     GError *tmp_err = NULL;
@@ -399,7 +400,9 @@ read_file(char *f, cr_CompressionType compression, char* buffer, int amount)
         ret = tmp_err->code;
         return ret;
     }
-    cr_read(orig, buffer, amount, &tmp_err);
+    int read = cr_read(orig, buffer, buffer_len-1, &tmp_err);
+    g_assert_cmpint(read, !=, CR_CW_ERR);
+    buffer[read] = 0;
     if (orig)
         cr_close(orig, NULL);
     return ret;

--- a/tests/test_misc.c
+++ b/tests/test_misc.c
@@ -586,6 +586,7 @@ compressfile_with_stat_test_text_file(Copyfiletest *copyfiletest,
     g_assert(g_file_test(copyfiletest->dst_file, G_FILE_TEST_IS_REGULAR));
     checksum = cr_checksum_file(TEST_TEXT_FILE, CR_CHECKSUM_SHA256, NULL);
     g_assert_cmpstr(stat->checksum, ==, checksum);
+    g_free(checksum);
     cr_contentstat_free(stat, &tmp_err);
     g_assert(!tmp_err);
 }
@@ -615,6 +616,7 @@ compressfile_with_stat_test_gz_file_gz_output(Copyfiletest *copyfiletest,
     g_assert(g_file_test(dst_full_name, G_FILE_TEST_IS_REGULAR));
     checksum = cr_checksum_file(TEST_TEXT_FILE, CR_CHECKSUM_SHA256, NULL);
     g_assert_cmpstr(stat->checksum, ==, checksum);
+    g_free(checksum);
 
     //assert content is readable after decompression and recompression
     char buf[30];
@@ -699,6 +701,7 @@ compressfile_test_sqlite_file_gz_output(Copyfiletest *copyfiletest,
     g_assert(g_file_test(dst_full_name, G_FILE_TEST_EXISTS));
 
     g_assert(!tmp_err);
+    g_free(dst_full_name);
 }
 
 

--- a/tests/test_modifyrepo_shared.c
+++ b/tests/test_modifyrepo_shared.c
@@ -86,7 +86,7 @@ test_cr_write_file(void)
     task->compress = 1;
 
     GError **err = NULL;
-    cr_write_file(repopath, task, CR_CW_GZ_COMPRESSION, err);
+    char * out = cr_write_file(repopath, task, CR_CW_GZ_COMPRESSION, err);
     
     //bz1639287 file should not be named text_file.gz.gz
     gchar *dst = g_strconcat(repopath, "/", "text_file.gz" , NULL);
@@ -96,6 +96,7 @@ test_cr_write_file(void)
     g_free(repopath);
     g_free(tmp_dir);
     g_free(dst);
+    g_free(out);
 }
 
 static void 

--- a/tests/test_sqlite.c
+++ b/tests/test_sqlite.c
@@ -134,6 +134,7 @@ test_cr_db_add_primary_pkg(TestData *testdata,
 
     // Cleanup
 
+    cr_package_free(pkg);
     g_timer_stop(timer);
     g_timer_destroy(timer);
     g_free(path);

--- a/tests/test_xml_dump.c
+++ b/tests/test_xml_dump.c
@@ -33,6 +33,7 @@ test_cr_Package_contains_forbidden_control_chars_01(void)
 {
     cr_Package *p = get_package();
     g_assert(!cr_Package_contains_forbidden_control_chars(p));
+    cr_package_free(p);
 }
 
 static void
@@ -42,6 +43,7 @@ test_cr_Package_contains_forbidden_control_chars_02(void)
     p->name = "foo";
 
     g_assert(cr_Package_contains_forbidden_control_chars(p));
+    cr_package_free(p);
 }
 
 static void
@@ -51,6 +53,7 @@ test_cr_Package_contains_forbidden_control_chars_03(void)
     p->summary = "foo";
 
     g_assert(cr_Package_contains_forbidden_control_chars(p));
+    cr_package_free(p);
 }
 
 static void
@@ -61,6 +64,7 @@ test_cr_Package_contains_forbidden_control_chars_04(void)
     dep->name = "foobar_dep";
 
     g_assert(cr_Package_contains_forbidden_control_chars(p));
+    cr_package_free(p);
 }
 
 static void
@@ -71,6 +75,7 @@ test_cr_Package_contains_forbidden_control_chars_05(void)
     file->name = "obar_dep";
 
     g_assert(cr_Package_contains_forbidden_control_chars(p));
+    cr_package_free(p);
 }
 
 static void
@@ -81,6 +86,7 @@ test_cr_GSList_of_cr_Dependency_contains_forbidden_control_chars_01(void)
     dep->name = "foobar_dep";
 
     g_assert(cr_GSList_of_cr_Dependency_contains_forbidden_control_chars(p->requires));
+    cr_package_free(p);
 }
 
 static void
@@ -91,6 +97,7 @@ test_cr_GSList_of_cr_Dependency_contains_forbidden_control_chars_02(void)
     dep->name = "fo	badep";
 
     g_assert(!cr_GSList_of_cr_Dependency_contains_forbidden_control_chars(p->requires));
+    cr_package_free(p);
 }
 
 int

--- a/tests/test_xml_dump_primary.c
+++ b/tests/test_xml_dump_primary.c
@@ -41,6 +41,7 @@ xmlNodePtr cmp_package_files_and_xml(GSList *files, xmlNodePtr current, int only
             g_assert_cmpstr((char *) current->properties->name, ==, "type");
             g_assert_cmpstr((char *) current->properties->children->content, ==, IF_NULL_EMPTY(entry->type));
         }
+        g_free(fullname);
     }
 
     return current->next;
@@ -273,8 +274,10 @@ test_cr_xml_dump_primary_dump_pco_00(void)
     xmlNodePtr node;
     node = xmlNewNode(NULL, BAD_CAST "wrapper");
     cr_xml_dump_primary_dump_pco(node, p, PCO_TYPE_REQUIRES);
-    node = node->children;
-    node = cmp_package_pco_and_xml(p->requires, node, PCO_TYPE_REQUIRES);
+    xmlNodePtr node_children = node->children;
+    cmp_package_pco_and_xml(p->requires, node_children, PCO_TYPE_REQUIRES);
+    xmlFreeNode(node);
+    cr_package_free(p);
 }
 
 static void
@@ -328,9 +331,12 @@ test_cr_xml_dump_primary_dump_pco_01(void)
     cr_xml_dump_primary_dump_pco(node, p, PCO_TYPE_REQUIRES);
     cr_xml_dump_primary_dump_pco(node, p, PCO_TYPE_OBSOLETES);
 
-    node = node->children;
-    node = cmp_package_pco_and_xml(p->requires, node, PCO_TYPE_REQUIRES);
-    node = cmp_package_pco_and_xml(p->obsoletes, node, PCO_TYPE_OBSOLETES);
+    xmlNodePtr node_children = node->children;
+    node_children = cmp_package_pco_and_xml(p->requires, node_children, PCO_TYPE_REQUIRES);
+    node_children = cmp_package_pco_and_xml(p->obsoletes, node_children, PCO_TYPE_OBSOLETES);
+
+    xmlFreeNode(node);
+    cr_package_free(p);
 }
 
 static void
@@ -346,6 +352,7 @@ test_cr_xml_dump_primary_base_items_00(void)
     cr_xml_dump_primary_base_items(node, pkg);
     cmp_package_and_xml_node(pkg, node);
 
+    xmlFreeNode(node);
     cr_package_free(pkg);
 }
 
@@ -363,6 +370,7 @@ test_cr_xml_dump_primary_base_items_01(void)
     cr_xml_dump_primary_base_items(node, pkg);
     cmp_package_and_xml_node(pkg, node);
 
+    xmlFreeNode(node);
     cr_package_free(pkg);
 }
 
@@ -379,6 +387,7 @@ test_cr_xml_dump_primary_base_items_02(void)
     cr_xml_dump_primary_base_items(node, pkg);
     cmp_package_and_xml_node(pkg, node);
 
+    xmlFreeNode(node);
     cr_package_free(pkg);
 }
 

--- a/tests/test_xml_parser_main_metadata_together.c
+++ b/tests/test_xml_parser_main_metadata_together.c
@@ -203,6 +203,7 @@ test_cr_xml_package_iterator_03_out_of_order_pkgs(void)
 
     g_assert(package == NULL);
     g_assert(tmp_err != NULL);
+    g_clear_error(&tmp_err);
 
     cr_PkgIterator_free(pkg_iterator, &tmp_err);
 }
@@ -217,6 +218,7 @@ test_cr_xml_package_iterator_04_invalid_path(void)
 
     g_assert(pkg_iterator == NULL);
     g_assert(tmp_err != NULL);
+    g_clear_error(&tmp_err);
 }
 
 static void
@@ -254,6 +256,7 @@ test_cr_xml_package_iterator_06_newpkgcb_interrupt(void)
 
     g_assert(package == NULL);
     g_assert(tmp_err != NULL);
+    g_clear_error(&tmp_err);
     g_assert_cmpint(new_cb_count, ==, 1);
 
     cr_PkgIterator_free(pkg_iterator, &tmp_err);


### PR DESCRIPTION
This should fix most of the detected problems. There still are several left that I wasn't able to figure out and I am not sure if they are problems in createrepo_c or if they are not false positives:
- Leaks in python unittest (this might be a python loading module problem - we see something like this even in dnf)
- Leaks in `g_option_context_parse`
- Inconsistent leaks from `xmlBufferCreate` from `cr_xml_dump_primary`
- Leak of `sqliterepocmdoptions_new`

Closes: https://github.com/rpm-software-management/createrepo_c/issues/384