### PR TITLE
Move cr_compress_groupfile outside WITH_LIBMODULEMD

### DIFF
--- a/src/metadata_internal.h
+++ b/src/metadata_internal.h
@@ -52,13 +52,13 @@ cr_metadata_load_modulemd(ModulemdModuleIndex **moduleindex,
  * @param dest_dir      Path to directory where the compressed groupfile should be stored.
  * @return              Path to the new compressed groupfile. Has to be freed by the caller.
  */
+
+#endif /* WITH_LIBMODULEMD */
+
 gchar *
 cr_compress_groupfile(const char *groupfile,
                       const char *dest_dir,
                       cr_CompressionType compression);
-
-
-#endif /* WITH_LIBMODULEMD */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This function is used in code which is not conditional under WITH_LIBMODULEMD therefore the declaration should also match its definition scope

Fixes build issues flagged by clang

src/createrepo_c.c:850:16: error: incompatible integer to pointer conversion initializing 'gchar *' (aka 'char *') with an
 expression of type 'int' [-Wint-conversion]
|   850 |         gchar *compressed_path = cr_compress_groupfile(cmd_options->groupfile_fullpath, tmp_out_repo, compression);
|       |                ^                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~