### PR TITLE
Python API: Fix a crash when setting pkg files

### DIFF
--- a/src/python/typeconversion.c
+++ b/src/python/typeconversion.c
@@ -200,8 +200,11 @@ PyObject_ToPackageFile(PyObject *tuple, GStringChunk *chunk)
     pyobj = PyTuple_GetItem(tuple, 2);
     file->name = PyObject_ToChunkedString(pyobj, chunk);
 
-    pyobj = PyTuple_GetItem(tuple, 3);
-    file->digest = PyObject_ToChunkedString(pyobj, chunk);
+    // The digest (part of filelists-ext) is optional, only set it in case it is present
+    if (PyTuple_Size(tuple) == 4) {
+        pyobj = PyTuple_GetItem(tuple, 3);
+        file->digest = PyObject_ToChunkedString(pyobj, chunk);
+    }
 
     return file;
 }

--- a/tests/python/tests/test_package.py
+++ b/tests/python/tests/test_package.py
@@ -202,8 +202,8 @@ class TestCasePackage(unittest.TestCase):
         self.assertEqual(pkg.recommends, [('foo_rec', 'GE', '0', '1.1.0', None, False)])
         pkg.supplements = [('foo_sup', 'GE', '0', '1.1.0', None, False)]
         self.assertEqual(pkg.supplements, [('foo_sup', 'GE', '0', '1.1.0', None, False)])
-        pkg.files = [(None, '/foo/', 'bar', 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')]
-        self.assertEqual(pkg.files, [(None, '/foo/', 'bar', 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')])
+        pkg.files = [(None, '/foo/', 'bar', 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'), (None, '/baz/', 'qux')]
+        self.assertEqual(pkg.files, [(None, '/baz/', 'qux'), (None, '/foo/', 'bar', 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')])
         pkg.changelogs = [('me', 123456, 'first commit')]
         self.assertEqual(pkg.changelogs, [('me', 123456, 'first commit')])
 


### PR DESCRIPTION
The fix in https://github.com/rpm-software-management/createrepo_c/pull/362 resolved the situation when getting pkg files from python. We need to also fix setting pkg files.

Make the digest optional in order to still support files without it.