### PR TITLE
Fix building on EL9

### DIFF
--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -63,7 +63,7 @@
  * Starting with glib 2.70.0, g_pattern_spec_match() replaces
  * g_pattern_match().
  */
-#ifdef GLIB_VERSION_2_70
+#if GLIB_CHECK_VERSION(2, 70, 0)
 #define PATTERN_MATCH g_pattern_spec_match
 #else
 #define PATTERN_MATCH g_pattern_match


### PR DESCRIPTION
The existing code is non-idiomatic, and as it so happens EL9 currently defines this macro unexpectedly despite not having the proper API, so we replace this with the idiomatic approach to make it actually work.

https://issues.redhat.com/browse/RHEL-12941
https://github.com/rpm-software-management/createrepo_c/pull/342/files#r1357391661