### PR TITLE
Don't allow building without zstd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,6 @@ if(NOT BUILD_LIBCREATEREPO_C_SHARED)
   set(CMAKE_POSITION_INDEPENDENT_CODE 1)
 endif()
 
-option(WITH_ZSTD "Build with zstd support" ON)
-
 option(CREATEREPO_C_INSTALL_DEVELOPMENT "Install createrepo_c development files." ON)
 option(CREATEREPO_C_INSTALL_MANPAGES "Install createrepo_c man-pages." ON)
 
@@ -47,6 +45,7 @@ pkg_check_modules(GTHREAD2 REQUIRED gthread-2.0)
 pkg_check_modules(LZMA REQUIRED liblzma)
 pkg_check_modules(SQLITE3 REQUIRED sqlite3)
 pkg_check_modules(RPM REQUIRED rpm)
+pkg_check_modules(ZSTD REQUIRED libzstd)
 
 pkg_check_modules(LIBMAGIC libmagic)
 # the pkg-config was only added in F33
@@ -64,6 +63,7 @@ include_directories(${GIO_INCLUDE_DIRS})
 include_directories(${LIBXML2_INCLUDE_DIR})
 include_directories(${OPENSSL_INCLUDE_DIR})
 include_directories(${ZLIB_INCLUDE_DIR})
+include_directories(${ZSTD_INCLUDE_DIRS})
 
 # SuSE/Mageia/Mandriva legacy weak deps support
 OPTION (ENABLE_LEGACY_WEAKDEPS "Enable legacy SUSE/Mageia/Mandriva weakdeps support?" ON)
@@ -104,12 +104,6 @@ IF (WITH_LIBMODULEMD)
     SET (CMAKE_C_FLAGS_DEBUG    "${CMAKE_C_FLAGS_DEBUG} -DWITH_LIBMODULEMD")
 ENDIF (WITH_LIBMODULEMD)
 
-if (WITH_ZSTD)
-    pkg_check_modules(ZSTD REQUIRED libzstd)
-    include_directories(${ZSTD_INCLUDE_DIRS})
-    SET (CMAKE_C_FLAGS          "${CMAKE_C_FLAGS} -DWITH_ZSTD")
-    SET (CMAKE_C_FLAGS_DEBUG    "${CMAKE_C_FLAGS_DEBUG} -DWITH_ZSTD")
-endif()
 
 if (WITH_SANITIZERS)
     message(WARNING "Building with sanitizers enabled!")

--- a/createrepo_c.spec
+++ b/createrepo_c.spec
@@ -18,11 +18,8 @@
 
 %if 0%{?rhel} && 0%{?rhel} < 7
 %bcond_with libmodulemd
-# dnf supports zstd since 8.4: https://bugzilla.redhat.com/show_bug.cgi?id=1914876
-%bcond_with zstd
 %else
 %bcond_without libmodulemd
-%bcond_without zstd
 %endif
 
 %if 0%{?rhel} && 0%{?rhel} <= 8
@@ -75,9 +72,8 @@ Requires: rpm >= 4.9.0
 %if %{with drpm}
 BuildRequires:  drpm-devel >= 0.4.0
 %endif
-%if %{with zstd}
+# dnf supports zstd since 8.4: https://bugzilla.redhat.com/show_bug.cgi?id=1914876
 BuildRequires:  pkgconfig(libzstd)
-%endif
 
 %if %{with sanitizers}
 BuildRequires:  libasan
@@ -135,7 +131,6 @@ pushd build-py3
       -DWITH_LIBMODULEMD=%{?with_libmodulemd:ON}%{!?with_libmodulemd:OFF} \
       -DWITH_LEGACY_HASHES=%{?with_legacy_hashes:ON}%{!?with_legacy_hashes:OFF} \
       -DENABLE_DRPM=%{?with_drpm:ON}%{!?with_drpm:OFF} \
-      -DWITH_ZSTD=%{?with_zstd:ON}%{!?with_zstd:OFF} \
       -DWITH_SANITIZERS=%{?with_sanitizers:ON}%{!?with_sanitizers:OFF}
   make %{?_smp_mflags} RPM_OPT_FLAGS="%{optflags}"
   # Build C documentation

--- a/src/compression_wrapper.c
+++ b/src/compression_wrapper.c
@@ -35,9 +35,7 @@
 #endif  // WITH_ZCHUNK
 #include "error.h"
 #include "compression_wrapper.h"
-#ifdef WITH_ZSTD
 #include <zstd.h>
-#endif
 
 
 #define ERR_DOMAIN                      CREATEREPO_C_ERROR
@@ -121,7 +119,6 @@ typedef struct {
     unsigned char buffer[XZ_BUFFER_SIZE];
 } XzFile;
 
-#ifdef WITH_ZSTD
 #define CR_CW_ZSTD_COMPRESSION_LEVEL    9
 typedef struct {
     void *buffer;
@@ -130,7 +127,6 @@ typedef struct {
     ZSTD_outBuffer zob;
     void * context;     //ZSTD_{C,D}Ctx
 } ZstdFile;
-#endif
 
 cr_CompressionType
 cr_detect_compression(const char *filename, GError **err)
@@ -440,7 +436,6 @@ cr_sopen(const char *filename,
             break;
 
         case (CR_CW_ZSTD_COMPRESSION): { // ------------------------------------
-#ifdef WITH_ZSTD
             FILE *f = fopen(filename, mode_str);
 
             if (!f) {
@@ -483,10 +478,6 @@ cr_sopen(const char *filename,
             file->FILE = (void *) zstd_file;
 
             break;
-#else
-            g_set_error(err, ERR_DOMAIN, CRE_IO, "createrepo_c wasn't compiled with zstd support");
-            break;
-#endif // WITH_ZSTD
         }
 
         case (CR_CW_BZ2_COMPRESSION): { // ------------------------------------
@@ -846,7 +837,6 @@ cr_close(CR_FILE *cr_file, GError **err)
             break;
 
         case (CR_CW_ZSTD_COMPRESSION): { // --------------------------------------
-#ifdef WITH_ZSTD
             ZstdFile * zstd = (ZstdFile *) cr_file->FILE;
             if (cr_file->mode == CR_CW_MODE_READ) {
                 ZSTD_freeDCtx(zstd->context);
@@ -877,10 +867,6 @@ cr_close(CR_FILE *cr_file, GError **err)
 
             ret = CRE_OK;
             break;
-#else
-            g_set_error(err, ERR_DOMAIN, CRE_IO, "createrepo_c wasn't compiled with zstd support");
-            break;
-#endif // WITH_ZSTD
         }
         case (CR_CW_BZ2_COMPRESSION): // --------------------------------------
             if (cr_file->mode == CR_CW_MODE_READ)
@@ -1094,7 +1080,6 @@ cr_read(CR_FILE *cr_file, void *buffer, unsigned int len, GError **err)
             break;
 
         case (CR_CW_ZSTD_COMPRESSION): { // ---------------------------------------
-#ifdef WITH_ZSTD
             ZstdFile * zstd = (ZstdFile *) cr_file->FILE;
 
             ZSTD_outBuffer zob = {buffer, len, 0};
@@ -1125,10 +1110,6 @@ cr_read(CR_FILE *cr_file, void *buffer, unsigned int len, GError **err)
             }
 
             break;
-#else
-            g_set_error(err, ERR_DOMAIN, CRE_IO, "createrepo_c wasn't compiled with zstd support");
-            break;
-#endif // WITH_ZSTD
         }
         case (CR_CW_BZ2_COMPRESSION): // --------------------------------------
             ret = BZ2_bzRead(&bzerror, (BZFILE *) cr_file->FILE, buffer, len);
@@ -1365,7 +1346,6 @@ cr_write(CR_FILE *cr_file, const void *buffer, unsigned int len, GError **err)
             break;
 
         case (CR_CW_ZSTD_COMPRESSION): { // ---------------------------------------
-#ifdef WITH_ZSTD
             ZstdFile * zstd = (ZstdFile *) cr_file->FILE;
             ZSTD_inBuffer zib = {buffer, len, 0};
 
@@ -1397,10 +1377,6 @@ cr_write(CR_FILE *cr_file, const void *buffer, unsigned int len, GError **err)
             }
 
             break;
-#else
-            g_set_error(err, ERR_DOMAIN, CRE_IO, "createrepo_c wasn't compiled with zstd support");
-            break;
-#endif // WITH_ZSTD
         }
 
         case (CR_CW_BZ2_COMPRESSION): // --------------------------------------

--- a/tests/test_compression_wrapper.c
+++ b/tests/test_compression_wrapper.c
@@ -103,10 +103,8 @@ test_cr_compression_suffix(void)
     suffix = cr_compression_suffix(CR_CW_XZ_COMPRESSION);
     g_assert_cmpstr(suffix, ==, ".xz");
 
-#ifdef WITH_ZSTD
     suffix = cr_compression_suffix(CR_CW_ZSTD_COMPRESSION);
     g_assert_cmpstr(suffix, ==, ".zst");
-#endif // WITH_ZSTD
 }
 
 static void
@@ -144,10 +142,8 @@ test_cr_compression_type(void)
     type = cr_compression_type("xz");
     g_assert_cmpint(type, ==, CR_CW_XZ_COMPRESSION);
 
-#ifdef WITH_ZSTD
     type = cr_compression_type("zstd");
     g_assert_cmpint(type, ==, CR_CW_ZSTD_COMPRESSION);
-#endif // WITH_ZSTD
 }
 
 static void
@@ -192,7 +188,6 @@ test_cr_detect_compression(void)
     g_assert_cmpint(ret, ==, CR_CW_XZ_COMPRESSION);
     g_assert(!tmp_err);
 
-#ifdef WITH_ZSTD
     // Zstd
 
     ret = cr_detect_compression(FILE_COMPRESSED_0_ZSTD, &tmp_err);
@@ -201,7 +196,6 @@ test_cr_detect_compression(void)
     ret = cr_detect_compression(FILE_COMPRESSED_1_ZSTD, &tmp_err);
     g_assert_cmpint(ret, ==, CR_CW_ZSTD_COMPRESSION);
     g_assert(!tmp_err);
-#endif // WITH_ZSTD
 }
 
 
@@ -247,7 +241,6 @@ test_cr_detect_compression_bad_suffix(void)
     g_assert_cmpint(ret, ==, CR_CW_XZ_COMPRESSION);
     g_assert(!tmp_err);
 
-#ifdef WITH_ZSTD
     // Zstd
 
     ret = cr_detect_compression(FILE_COMPRESSED_0_ZSTD_BAD_SUFFIX, &tmp_err);
@@ -256,7 +249,6 @@ test_cr_detect_compression_bad_suffix(void)
     ret = cr_detect_compression(FILE_COMPRESSED_1_ZSTD_BAD_SUFFIX, &tmp_err);
     g_assert_cmpint(ret, ==, CR_CW_ZSTD_COMPRESSION);
     g_assert(!tmp_err);
-#endif // WITH_ZSTD
 }
 
 
@@ -328,14 +320,12 @@ test_cr_read_with_autodetection(void)
     test_helper_cw_input(FILE_COMPRESSED_1_XZ, CR_CW_AUTO_DETECT_COMPRESSION,
             FILE_COMPRESSED_1_CONTENT, FILE_COMPRESSED_1_CONTENT_LEN);
 
-#ifdef WITH_ZSTD
     // Zstd
 
     test_helper_cw_input(FILE_COMPRESSED_0_ZSTD, CR_CW_AUTO_DETECT_COMPRESSION,
             FILE_COMPRESSED_0_CONTENT, FILE_COMPRESSED_0_CONTENT_LEN);
     test_helper_cw_input(FILE_COMPRESSED_1_ZSTD, CR_CW_AUTO_DETECT_COMPRESSION,
             FILE_COMPRESSED_1_CONTENT, FILE_COMPRESSED_1_CONTENT_LEN);
-#endif // WITH_ZSTD
 }
 
 
@@ -503,7 +493,6 @@ outputtest_cw_output(Outputtest *outputtest,
                           CR_CW_XZ_COMPRESSION, FILE_COMPRESSED_1_CONTENT,
                           FILE_COMPRESSED_1_CONTENT_LEN);
 
-#ifdef WITH_ZSTD
     // Zstd
 
     test_helper_cw_output(OUTPUT_TYPE_WRITE,  outputtest->tmp_filename,
@@ -524,7 +513,6 @@ outputtest_cw_output(Outputtest *outputtest,
     test_helper_cw_output(OUTPUT_TYPE_PRINTF, outputtest->tmp_filename,
                           CR_CW_ZSTD_COMPRESSION, FILE_COMPRESSED_1_CONTENT,
                           FILE_COMPRESSED_1_CONTENT_LEN);
-#endif // WITH_ZSTD
 }
 
 
@@ -586,14 +574,12 @@ test_cr_error_handling(void)
     g_error_free(tmp_err);
     tmp_err = NULL;
 
-#ifdef WITH_ZSTD
     f = cr_open("/", CR_CW_MODE_WRITE, CR_CW_ZSTD_COMPRESSION, &tmp_err);
     g_assert(!f);
     g_assert(tmp_err);
     g_assert_cmpint(tmp_err->code, ==, CRE_IO);
     g_error_free(tmp_err);
     tmp_err = NULL;
-#endif // WITH_ZSTD
 
     // Opening plain text file as compressed
 
@@ -638,7 +624,6 @@ test_cr_error_handling(void)
     g_assert_cmpint(ret, ==, CRE_OK);
     g_assert(!tmp_err);
 
-#ifdef WITH_ZSTD
     f = cr_open(FILE_COMPRESSED_1_PLAIN, CR_CW_MODE_READ,
                 CR_CW_ZSTD_COMPRESSION, &tmp_err);
     g_assert(f);
@@ -651,7 +636,6 @@ test_cr_error_handling(void)
     ret = cr_close(f, &tmp_err);
     g_assert_cmpint(ret, ==, CRE_OK);
     g_assert(!tmp_err);
-#endif // WITH_ZSTD
 }
 
 
@@ -773,7 +757,6 @@ test_contentstating_singlewrite(Outputtest *outputtest,
     cr_contentstat_free(stat, &tmp_err);
     g_assert(!tmp_err);
 
-#ifdef WITH_ZSTD
     // zstd compression
     stat = cr_contentstat_new(CR_CHECKSUM_SHA256, &tmp_err);
     g_assert(stat);
@@ -798,7 +781,6 @@ test_contentstating_singlewrite(Outputtest *outputtest,
     g_assert_cmpstr(stat->checksum, ==, content_sha256);
     cr_contentstat_free(stat, &tmp_err);
     g_assert(!tmp_err);
-#endif // WITH_ZSTD
 }
 
 static void
@@ -845,7 +827,6 @@ test_contentstating_multiwrite(Outputtest *outputtest,
     cr_contentstat_free(stat, &tmp_err);
     g_assert(!tmp_err);
 
-#ifdef WITH_ZSTD
     // Zstd compression
 
     stat = cr_contentstat_new(CR_CHECKSUM_SHA256, &tmp_err);
@@ -875,7 +856,6 @@ test_contentstating_multiwrite(Outputtest *outputtest,
     g_assert_cmpstr(stat->checksum, ==, content_sha256);
     cr_contentstat_free(stat, &tmp_err);
     g_assert(!tmp_err);
-#endif // WITH_ZSTD
 }
 
 static void


### PR DESCRIPTION
Since zstd is the default compression building without leads to broken default runs.

Alternative to: https://github.com/rpm-software-management/createrepo_c/pull/379