### PR TITLE
Add a --no-pretty option to reduce repo metadata size

### DIFF
--- a/doc/createrepo_c.8
+++ b/doc/createrepo_c.8
@@ -85,6 +85,9 @@ Choose the checksum type used in repomd.xml and for packages in the metadata. Th
 .SS \-p \-\-pretty
 .sp
 Make sure all xml generated is formatted (default)
+.SS \-p \-\-no\-pretty
+.sp
+Minify the generated xml content. On average this reduces compressed size by 2%.
 .SS \-d \-\-database
 .sp
 Generate sqlite databases for use with yum.

--- a/src/cmd_parser.c
+++ b/src/cmd_parser.c
@@ -37,6 +37,7 @@
 #define DEFAULT_UNIQUE_MD_FILENAMES     TRUE
 #define DEFAULT_IGNORE_LOCK             FALSE
 #define DEFAULT_LOCAL_SQLITE            FALSE
+#define DEFAULT_FORMAT_PRETTY           TRUE
 
 struct CmdOptions _cmd_options = {
         .changelog_limit            = DEFAULT_CHANGELOG_LIMIT,
@@ -54,7 +55,7 @@ struct CmdOptions _cmd_options = {
         .cut_dirs                   = 0,
         .location_prefix            = NULL,
         .repomd_checksum            = NULL,
-
+        .pretty                     = DEFAULT_FORMAT_PRETTY,
         .deltas                     = FALSE,
         .oldpackagedirs             = NULL,
         .num_deltas                 = 1,
@@ -115,6 +116,8 @@ static GOptionEntry cmd_entries[] =
       "metadata. The default is now \"sha256\".", "CHECKSUM_TYPE" },
     { "pretty", 'p', 0, G_OPTION_ARG_NONE, &(_cmd_options.pretty),
       "Make sure all xml generated is formatted (default)", NULL },
+    { "no-pretty", 0, G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE, &(_cmd_options.pretty),
+      "No extra indentation in generated xml", NULL },
     { "database", 'd', 0, G_OPTION_ARG_NONE, &(_cmd_options.database),
       "Generate sqlite databases for use with yum.", NULL },
     { "no-database", 0, 0, G_OPTION_ARG_NONE, &(_cmd_options.no_database),

--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -736,6 +736,7 @@ main(int argc, char **argv)
     // Init package parser
     cr_package_parser_init();
     cr_xml_dump_init();
+    cr_xml_dump_set_parameter(CR_XML_DUMP_DO_PRETTY_PRINT, cmd_options->pretty);
 
     // Thread pool - Creation
     struct UserData user_data = {0};

--- a/src/modifyrepo_c.c
+++ b/src/modifyrepo_c.c
@@ -104,7 +104,7 @@ parse_arguments(int *argc, char ***argv, RawCmdOptions *options, GError **err)
 
     };
 
-    // Frstly, set default values
+    // Firstly, set default values
     options->version = FALSE;
     options->mdtype = NULL;
     options->remove = NULL;

--- a/src/xml_dump.c
+++ b/src/xml_dump.c
@@ -29,12 +29,41 @@
 #include "xml_dump_internal.h"
 
 
+static int _xml_dump_parameters[CR_XML_DUMP_OPTION_COUNT];
+
 void
 cr_xml_dump_init()
 {
     xmlInitParser();
+
+    /* Default Settings for parameters */
+    _xml_dump_parameters[CR_XML_DUMP_DO_PRETTY_PRINT] = TRUE;
 }
 
+void cr_xml_dump_set_parameter(cr_dump_parameter param, int value)
+{
+    switch(param) {
+        case CR_XML_DUMP_DO_PRETTY_PRINT:
+            _xml_dump_parameters[param] = value;
+        break;
+        default:
+            /* undefined parameter, ignored. */
+        break;
+    }
+}
+
+/** Get the value of one xml dump parameter.
+*/
+int cr_xml_dump_get_parameter(cr_dump_parameter param) {
+    switch (param) {
+        case CR_XML_DUMP_DO_PRETTY_PRINT:
+            return _xml_dump_parameters[param];
+        default:
+            break;
+    }
+
+    return 0;
+}
 
 void
 cr_xml_dump_cleanup()

--- a/src/xml_dump.h
+++ b/src/xml_dump.h
@@ -85,9 +85,29 @@ struct cr_XmlStruct {
     char *other;            /*!< XML chunk for other.xml */
 };
 
-/** Initialize dumping part of library (Initialize libxml2).
+/** Xml dump options
  */
+typedef enum {
+    CR_XML_DUMP_DO_PRETTY_PRINT,   /* do a pretty print when dumping the XML */
+
+    CR_XML_DUMP_OPTION_COUNT,
+    CR_XML_DUMP_OPTION_MAX = 1024
+} cr_dump_parameter;
+
+/** Initialize dumping part of library. Call only once from the main thread.
+ *
+ * Initializes libxml2.
+ */
+
 void cr_xml_dump_init();
+
+/** Set one xml dump parameter.
+*/
+void cr_xml_dump_set_parameter(cr_dump_parameter param, int value);
+
+/** Get the value of one xml dump parameter.
+*/
+int cr_xml_dump_get_parameter(cr_dump_parameter param);
 
 /** Cleanup initialized dumping part of library
  */

--- a/src/xml_dump_deltapackage.c
+++ b/src/xml_dump_deltapackage.c
@@ -105,7 +105,8 @@ char *
 cr_xml_dump_deltapackage(cr_DeltaPackage *package, GError **err)
 {
     xmlNodePtr root;
-    char *result;
+    char *result, *p;
+    gboolean xml_dump_pretty = cr_xml_dump_get_parameter(CR_XML_DUMP_DO_PRETTY_PRINT);
 
     assert(!err || *err == NULL);
 
@@ -129,15 +130,16 @@ cr_xml_dump_deltapackage(cr_DeltaPackage *package, GError **err)
     root = xmlNewNode(NULL, BAD_CAST "delta");
     cr_xml_dump_delta(root, package);
     // xmlNodeDump seems to be a little bit faster than xmlDocDumpFormatMemory
-    xmlNodeDump(buf, NULL, root, 2, FORMAT_XML);
+    xmlNodeDump(buf, NULL, root, 2, xml_dump_pretty);
     assert(buf->content);
     // First line in the buf is not indented, we must indent it by ourself
-    result = g_malloc(sizeof(char *) * buf->use + INDENT + 1);
-    for (int x = 0; x < INDENT; x++) result[x] = ' ';
-    memcpy(result+INDENT, buf->content, buf->use);
-    result[buf->use + INDENT]   = '\n';
-    result[buf->use + INDENT + 1]   = '\0';
-
+    result = p = g_malloc(sizeof(char *) * buf->use + INDENT + 1);
+    if (xml_dump_pretty) {
+        for (int x = 0; x < INDENT; x++, p++) result[x] = ' ';
+    }
+    memcpy(p, buf->content, buf->use);
+    p[buf->use]   = '\n';
+    p[buf->use + 1]   = '\0';
 
     // Cleanup
 

--- a/src/xml_dump_filelists.c
+++ b/src/xml_dump_filelists.c
@@ -82,6 +82,7 @@ cr_xml_dump_filelists_chunk(cr_Package *package, gboolean filelists_ext, GError 
 {
     xmlNodePtr root;
     char *result;
+    gboolean xml_dump_pretty = cr_xml_dump_get_parameter(CR_XML_DUMP_DO_PRETTY_PRINT);
 
     assert(!err || *err == NULL);
 
@@ -105,7 +106,7 @@ cr_xml_dump_filelists_chunk(cr_Package *package, gboolean filelists_ext, GError 
     root = xmlNewNode(NULL, BAD_CAST "package");
     cr_xml_dump_filelists_items(root, package, filelists_ext);
     // xmlNodeDump seems to be a little bit faster than xmlDocDumpFormatMemory
-    xmlNodeDump(buf, NULL, root, FORMAT_LEVEL, FORMAT_XML);
+    xmlNodeDump(buf, NULL, root, 0, xml_dump_pretty);
     assert(buf->content);
     result = g_strndup((char *) buf->content, (buf->use+1));
     result[buf->use]     = '\n';

--- a/src/xml_dump_internal.h
+++ b/src/xml_dump_internal.h
@@ -30,9 +30,6 @@ extern "C" {
 #define XML_DOC_VERSION "1.0"
 #define XML_ENCODING    "UTF-8"
 
-#define FORMAT_XML      1
-#define FORMAT_LEVEL    0
-
 #define DATE_STR_MAX_LEN        32
 #define SIZE_STR_MAX_LEN        32
 

--- a/src/xml_dump_other.c
+++ b/src/xml_dump_other.c
@@ -117,6 +117,7 @@ cr_xml_dump_other(cr_Package *package, GError **err)
 {
     xmlNodePtr root;
     char *result;
+    gboolean xml_dump_pretty = cr_xml_dump_get_parameter(CR_XML_DUMP_DO_PRETTY_PRINT);
 
     assert(!err || *err == NULL);
 
@@ -140,7 +141,7 @@ cr_xml_dump_other(cr_Package *package, GError **err)
     root = xmlNewNode(NULL, BAD_CAST "package");
     cr_xml_dump_other_items(root, package);
     // xmlNodeDump seems to be a little bit faster than xmlDocDumpFormatMemory
-    xmlNodeDump(buf, NULL, root, FORMAT_LEVEL, FORMAT_XML);
+    xmlNodeDump(buf, NULL, root, 0, xml_dump_pretty);
     assert(buf->content);
     result = g_strndup((char *) buf->content, (buf->use+1));
     result[buf->use]     = '\n';

--- a/src/xml_dump_primary.c
+++ b/src/xml_dump_primary.c
@@ -382,6 +382,7 @@ cr_xml_dump_primary(cr_Package *package, GError **err)
 {
     xmlNodePtr root;
     char *result;
+    gboolean xml_dump_pretty = cr_xml_dump_get_parameter(CR_XML_DUMP_DO_PRETTY_PRINT);
 
     assert(!err || *err == NULL);
 
@@ -404,7 +405,7 @@ cr_xml_dump_primary(cr_Package *package, GError **err)
     root = xmlNewNode(NULL, BAD_CAST "package");
     cr_xml_dump_primary_base_items(root, package);
     // xmlNodeDump seems to be a little bit faster than xmlDocDumpFormatMemory
-    xmlNodeDump(buf, NULL, root, FORMAT_LEVEL, FORMAT_XML);
+    xmlNodeDump(buf, NULL, root, 0, xml_dump_pretty);
     assert(buf->content);
     result = g_strndup((char *) buf->content, (buf->use+1));
     result[buf->use]     = '\n';

--- a/src/xml_dump_repomd.c
+++ b/src/xml_dump_repomd.c
@@ -231,6 +231,7 @@ cr_xml_dump_repomd(cr_Repomd *repomd, GError **err)
     xmlDocPtr doc;
     xmlNodePtr root;
     char *result;
+    gboolean xml_dump_pretty = cr_xml_dump_get_parameter(CR_XML_DUMP_DO_PRETTY_PRINT);
 
     assert(!err || *err == NULL);
 
@@ -251,7 +252,7 @@ cr_xml_dump_repomd(cr_Repomd *repomd, GError **err)
                               (xmlChar **) &result,
                               NULL,
                               XML_ENCODING,
-                              FORMAT_XML);
+                              xml_dump_pretty);
 
     // Clean up
 

--- a/src/xml_dump_updateinfo.c
+++ b/src/xml_dump_updateinfo.c
@@ -201,6 +201,7 @@ cr_xml_dump_updateinfo(cr_UpdateInfo *updateinfo, GError **err)
     xmlDocPtr doc;
     xmlNodePtr root;
     char *result;
+    gboolean xml_dump_pretty = cr_xml_dump_get_parameter(CR_XML_DUMP_DO_PRETTY_PRINT);
 
     assert(!err || *err == NULL);
 
@@ -217,7 +218,7 @@ cr_xml_dump_updateinfo(cr_UpdateInfo *updateinfo, GError **err)
                               (xmlChar **) &result,
                               NULL,
                               XML_ENCODING,
-                              FORMAT_XML);
+                              xml_dump_pretty);
 
     // Clean up
 
@@ -230,7 +231,8 @@ char *
 cr_xml_dump_updaterecord(cr_UpdateRecord *rec, GError **err)
 {
     xmlNodePtr root;
-    char *result;
+    char *result, *p;
+    gboolean xml_dump_pretty = cr_xml_dump_get_parameter(CR_XML_DUMP_DO_PRETTY_PRINT);
 
     assert(!err || *err == NULL);
 
@@ -252,14 +254,16 @@ cr_xml_dump_updaterecord(cr_UpdateRecord *rec, GError **err)
 
     root = cr_xml_dump_updateinforecord_internal(NULL, rec);
     // xmlNodeDump seems to be a little bit faster than xmlDocDumpFormatMemory
-    xmlNodeDump(buf, NULL, root, 1, FORMAT_XML);
+    xmlNodeDump(buf, NULL, root, 1, xml_dump_pretty);
     assert(buf->content);
     // First line in the buf is not indented, we must indent it by ourself
-    result = g_malloc(sizeof(char *) * buf->use + INDENT + 1);
-    for (int x = 0; x < INDENT; x++) result[x] = ' ';
-    memcpy(result+INDENT, buf->content, buf->use);
-    result[buf->use + INDENT]   = '\n';
-    result[buf->use + INDENT + 1]   = '\0';
+    result = p = g_malloc(sizeof(char *) * buf->use + INDENT + 1);
+    if (xml_dump_pretty) {
+        for (int x = 0; x < INDENT; x++, p++) result[x] = ' ';
+    }
+    memcpy(p, buf->content, buf->use);
+    p[buf->use]   = '\n';
+    p[buf->use + 1]   = '\0';
 
     // Cleanup
 


### PR DESCRIPTION
The indentation might be pretty, but it also adds a few percent of compressed size to the metadata. for production use a --no-pretty can now be set that reduces the amount of blanks in the repodata xml.