### PR TITLE
build: Restore compatiblity with libxml2-2.12.0

### DIFF
--- a/src/sqlite.c
+++ b/src/sqlite.c
@@ -28,6 +28,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <libxml/encoding.h>
+#include <libxml/xmlstring.h>
 #include "misc.h"
 #include "sqlite.h"
 #include "error.h"


### PR DESCRIPTION
fail here: https://copr.fedorainfracloud.org/coprs/rpmsoftwaremanagement/dnf-nightly/build/6668781/
pass here: https://copr.fedorainfracloud.org/coprs/nsella/dnf5_stack_fix_xml/build/6670347/