### PR TITLE
SQLite: Enable shared cache on connection level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ pkg_check_modules(GLIB2 REQUIRED glib-2.0)
 pkg_check_modules(GIO REQUIRED gio-2.0)
 pkg_check_modules(GTHREAD2 REQUIRED gthread-2.0)
 pkg_check_modules(LZMA REQUIRED liblzma)
-pkg_check_modules(SQLITE3 REQUIRED sqlite3)
+pkg_check_modules(SQLITE3 REQUIRED sqlite3>=3.6.18)
 pkg_check_modules(RPM REQUIRED rpm)
 pkg_check_modules(ZSTD REQUIRED libzstd)
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Package build requires - Pkg name in Fedora/Ubuntu:
 * python (http://python.org/) - python3-devel/libpython3-dev
 * rpm (http://www.rpm.org/) - rpm-devel/librpm-dev
 * openssl (http://www.openssl.org/) - openssl-devel/libssl-dev
-* sqlite3 (https://sqlite.org/) - sqlite-devel/libsqlite3-dev
+* sqlite3 >= 3.6.18 (https://sqlite.org/) - sqlite-devel/libsqlite3-dev
 * xz (http://tukaani.org/xz/) - xz-devel/liblzma-dev
 * zchunk (https://github.com/zchunk/zchunk) - zchunk-devel/
 * zlib (http://www.zlib.net/) - zlib-devel/zlib1g-dev

--- a/createrepo_c.spec
+++ b/createrepo_c.spec
@@ -49,7 +49,7 @@ BuildRequires:  libcurl-devel
 BuildRequires:  libxml2-devel
 BuildRequires:  openssl-devel
 BuildRequires:  rpm-devel >= 4.8.0-28
-BuildRequires:  sqlite-devel
+BuildRequires:  sqlite-devel >= 3.6.18
 BuildRequires:  xz
 BuildRequires:  xz-devel
 BuildRequires:  zlib-devel

--- a/src/sqlite.c
+++ b/src/sqlite.c
@@ -111,7 +111,9 @@ open_sqlite_db(const char *path, GError **err)
 
     assert(!err || *err == NULL);
 
-    rc = sqlite3_open(path, &db);
+    rc = sqlite3_open_v2(path, &db,
+            SQLITE_OPEN_READWRITE|SQLITE_OPEN_CREATE|SQLITE_OPEN_SHAREDCACHE,
+            NULL);
     if (rc != SQLITE_OK) {
         g_set_error(err, ERR_DOMAIN, CRE_DB,
                     "Can not open SQL database: %s", sqlite3_errmsg(db));
@@ -1538,8 +1540,6 @@ cr_db_open(const char *path, cr_DatabaseType db_type, GError **err)
             // because --local-sqlite option was used
             exists = FALSE;
     }
-
-    sqlite3_enable_shared_cache(1);
 
     db = open_sqlite_db(path, &tmp_err);
     if (tmp_err) {


### PR DESCRIPTION
SQLite shared cache is discouraged and SQLite can be compiled without a support for it. If the support is disabled,
sqlite3_enable_shared_cache() function is not provided by the library and building createrepo_c fails.

This patch moves from sqlite3_enable_shared_cache() to a newer sqlite3_open_v2(,, SQLITE_OPEN_SHAREDCACHE,) API available since SQLite 3.6.18 (2009-09-11).

This has four effects:

(1) Building passes even if shared cache is not supported by SQLite.

(2) If the support is not available at run-time, SQLite keeps working.

(3) The shared cache is only enabled on connections createrep_c library opens. It does not affect SQLite connections made by different libraries or an application.

(4) sqlite >= 3.6.18 is required for building.

https://github.com/rpm-software-management/createrepo_c/issues/404 https://www.sqlite.org/c3ref/enable_shared_cache.html