### PR TITLE
Use Epoch-friendly sub-package interdependencies

### DIFF
--- a/createrepo_c.spec
+++ b/createrepo_c.spec
@@ -40,6 +40,8 @@ License:        GPL-2.0-or-later
 URL:            https://github.com/rpm-software-management/createrepo_c
 Source0:        %{url}/archive/%{version}/%{name}-%{version}.tar.gz
 
+%global epoch_dep %{?epoch:%{epoch}:}
+
 BuildRequires:  cmake
 BuildRequires:  gcc
 BuildRequires:  bzip2-devel
@@ -67,7 +69,7 @@ BuildRequires:  libmodulemd
 Requires:       libmodulemd%{?_isa} >= %{libmodulemd_version}
 %endif
 %endif
-Requires:       %{name}-libs =  %{version}-%{release}
+Requires:       %{name}-libs = %{epoch_dep}%{version}-%{release}
 BuildRequires:  bash-completion
 Requires: rpm >= 4.9.0
 %if %{with drpm}
@@ -84,7 +86,7 @@ BuildRequires:  libubsan
 
 %if 0%{?fedora} || 0%{?rhel} > 7
 Obsoletes:      createrepo < 0.11.0
-Provides:       createrepo = %{version}-%{release}
+Provides:       createrepo = %{epoch_dep}%{version}-%{release}
 %endif
 
 %description
@@ -102,7 +104,7 @@ for easy manipulation with a repodata.
 
 %package devel
 Summary:    Library for repodata manipulation
-Requires:   %{name}-libs%{?_isa} = %{version}-%{release}
+Requires:   %{name}-libs%{?_isa} = %{epoch_dep}%{version}-%{release}
 
 %description devel
 This package contains the createrepo_c C library and header files.
@@ -114,7 +116,7 @@ Summary:        Python 3 bindings for the createrepo_c library
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
 BuildRequires:  python3-sphinx
-Requires:       %{name}-libs = %{version}-%{release}
+Requires:       %{name}-libs = %{epoch_dep}%{version}-%{release}
 
 %description -n python3-%{name}
 Python 3 bindings for the createrepo_c library.


### PR DESCRIPTION
This helps with minimizing downstream-patches for custom createrepo_c builds with bumped Epoch (useful for the Copr team, we need to maintain a custom createrep_c build with legacy hashes enabled, and bumped epoch protects us from random upgrades to the system-default version).