### PR TITLE
Hide private functions from createrepo_c library

### DIFF
--- a/src/compression_wrapper.c
+++ b/src/compression_wrapper.c
@@ -286,7 +286,7 @@ cr_gz_strerror(gzFile f)
 }
 
 #ifdef WITH_ZCHUNK
-cr_ChecksumType
+static cr_ChecksumType
 cr_cktype_from_zck(zckCtx *zck, GError **err)
 {
     int cktype = zck_get_full_hash_type(zck);

--- a/src/deltarpms.c
+++ b/src/deltarpms.c
@@ -625,7 +625,7 @@ typedef struct {
     size_t prefix_len;
 } cr_PrestoDeltaUserData;
 
-void
+static void
 cr_prestodeltatask_free(cr_PrestoDeltaTask *task)
 {
     if (!task)

--- a/src/dumper_thread.c
+++ b/src/dumper_thread.c
@@ -421,7 +421,7 @@ exit:
     return checksum;
 }
 
-gchar *
+static gchar *
 prepare_split_media_baseurl(int media_id, const char *location_base)
 {
     // Default location_base "media:" in split mode

--- a/src/load_metadata.c
+++ b/src/load_metadata.c
@@ -76,13 +76,13 @@ cr_metadata_modulemd(cr_Metadata *md)
 }
 #endif /* WITH_LIBMODULEMD */
 
-void
+static void
 cr_free_values(gpointer data)
 {
     cr_package_free((cr_Package *) data);
 }
 
-GHashTable *
+static GHashTable *
 cr_new_metadata_hashtable()
 {
     GHashTable *hashtable = g_hash_table_new_full(g_str_hash, g_str_equal,
@@ -90,7 +90,7 @@ cr_new_metadata_hashtable()
     return hashtable;
 }
 
-void
+static void
 cr_destroy_metadata_hashtable(GHashTable *hashtable)
 {
     if (hashtable)

--- a/src/misc.c
+++ b/src/misc.c
@@ -831,7 +831,7 @@ cr_better_copy_file(const char *src, const char *in_dst, GError **err)
     return TRUE;
 }
 
-int
+static int
 cr_remove_dir_cb(const char *fpath,
                  G_GNUC_UNUSED const struct stat *sb,
                  G_GNUC_UNUSED int typeflag,

--- a/src/package.c
+++ b/src/package.c
@@ -181,7 +181,7 @@ cr_package_copy(cr_Package *orig)
     return pkg;
 }
 
-void
+__attribute__ ((visibility("hidden"))) void
 cr_package_copy_into(cr_Package *orig, cr_Package *pkg)
 {
     pkg->pkgKey           = orig->pkgKey;

--- a/src/repomd.c
+++ b/src/repomd.c
@@ -113,7 +113,7 @@ cr_repomd_record_copy(const cr_RepomdRecord *orig)
     return rec;
 }
 
-cr_ContentStat *
+static cr_ContentStat *
 cr_get_compressed_content_stat(const char *filename,
                                cr_ChecksumType checksum_type,
                                GError **err)

--- a/src/sqlite.c
+++ b/src/sqlite.c
@@ -1075,7 +1075,7 @@ db_package_ids_write(sqlite3 *db,
 
 // Primary.sqlite interface
 
-void
+static void
 cr_db_destroy_primary_statements(cr_DbPrimaryStatements stmts)
 {
     if (!stmts)
@@ -1105,7 +1105,7 @@ cr_db_destroy_primary_statements(cr_DbPrimaryStatements stmts)
 }
 
 
-cr_DbPrimaryStatements
+static cr_DbPrimaryStatements
 cr_db_prepare_primary_statements(sqlite3 *db, GError **err)
 {
     assert(!err || *err == NULL);
@@ -1193,7 +1193,7 @@ error:
 }
 
 
-void
+static void
 cr_db_add_primary_pkg(cr_DbPrimaryStatements stmts,
                       cr_Package *pkg,
                       GError **err)
@@ -1327,7 +1327,7 @@ cr_db_add_primary_pkg(cr_DbPrimaryStatements stmts,
 // filelists.sqlite interface
 
 
-void
+static void
 cr_db_destroy_filelists_statements(cr_DbFilelistsStatements stmts)
 {
     if (!stmts)
@@ -1341,7 +1341,7 @@ cr_db_destroy_filelists_statements(cr_DbFilelistsStatements stmts)
 }
 
 
-cr_DbFilelistsStatements
+static cr_DbFilelistsStatements
 cr_db_prepare_filelists_statements(sqlite3 *db, GError **err)
 {
     GError *tmp_err = NULL;
@@ -1373,7 +1373,7 @@ error:
 }
 
 
-void
+static void
 cr_db_add_filelists_pkg(cr_DbFilelistsStatements stmts,
                         cr_Package *pkg,
                         GError **err)
@@ -1414,7 +1414,7 @@ cr_db_add_filelists_pkg(cr_DbFilelistsStatements stmts,
 // other.sqlite interface
 
 
-void
+static void
 cr_db_destroy_other_statements(cr_DbOtherStatements stmts)
 {
     if (!stmts)
@@ -1428,7 +1428,7 @@ cr_db_destroy_other_statements(cr_DbOtherStatements stmts)
 }
 
 
-cr_DbOtherStatements
+static cr_DbOtherStatements
 cr_db_prepare_other_statements(sqlite3 *db, GError **err)
 {
     GError *tmp_err = NULL;
@@ -1460,7 +1460,7 @@ error:
 }
 
 
-void
+static void
 cr_db_add_other_pkg(cr_DbOtherStatements stmts, cr_Package *pkg, GError **err)
 {
     int rc;

--- a/src/xml_dump.c
+++ b/src/xml_dump.c
@@ -116,7 +116,7 @@ cr_latin1_to_utf8(const unsigned char *in, unsigned char *out)
     *out = '\0';
 }
 
-xmlNodePtr
+__attribute__ ((visibility("hidden"))) xmlNodePtr
 cr_xmlNewTextChild(xmlNodePtr parent,
                    xmlNsPtr ns,
                    const xmlChar *name,
@@ -145,7 +145,7 @@ cr_xmlNewTextChild(xmlNodePtr parent,
     return child;
 }
 
-xmlAttrPtr
+__attribute__ ((visibility("hidden"))) xmlAttrPtr
 cr_xmlNewProp(xmlNodePtr node, const xmlChar *name, const xmlChar *orig_content)
 {
     int free_content = 0;
@@ -171,7 +171,7 @@ cr_xmlNewProp(xmlNodePtr node, const xmlChar *name, const xmlChar *orig_content)
     return attr;
 }
 
-void
+__attribute__ ((visibility("hidden")))  void
 cr_xml_dump_files(xmlNodePtr node, cr_Package *package, int primary, gboolean filelists_ext)
 {
     if (!node || !package->files) {
@@ -306,7 +306,7 @@ cr_Package_contains_forbidden_control_chars(cr_Package *pkg)
     return 0;
 }
 
-struct cr_XmlStruct
+static struct cr_XmlStruct
 cr_xml_dump_int(cr_Package *pkg, gboolean filelists_ext, GError **err)
 {
     struct cr_XmlStruct result;

--- a/src/xml_dump_deltapackage.c
+++ b/src/xml_dump_deltapackage.c
@@ -34,7 +34,7 @@
 #define ERR_DOMAIN      CREATEREPO_C_ERROR
 #define INDENT          4
 
-void
+static void
 cr_xml_dump_delta(xmlNodePtr root, cr_DeltaPackage *package)
 {
     /***********************************

--- a/src/xml_dump_filelists.c
+++ b/src/xml_dump_filelists.c
@@ -31,7 +31,7 @@
 #define ERR_DOMAIN      CREATEREPO_C_ERROR
 
 
-void
+static void
 cr_xml_dump_filelists_items(xmlNodePtr root, cr_Package *package, gboolean filelists_ext)
 {
     /***********************************
@@ -77,7 +77,7 @@ cr_xml_dump_filelists_items(xmlNodePtr root, cr_Package *package, gboolean filel
 }
 
 
-char *
+static char *
 cr_xml_dump_filelists_chunk(cr_Package *package, gboolean filelists_ext, GError **err)
 {
     xmlNodePtr root;

--- a/src/xml_dump_other.c
+++ b/src/xml_dump_other.c
@@ -32,7 +32,7 @@
 #define ERR_DOMAIN      CREATEREPO_C_ERROR
 
 
-void
+static void
 cr_xml_dump_other_changelog(xmlNodePtr root, cr_Package *package)
 {
     if (!package->changelogs) {
@@ -70,7 +70,7 @@ cr_xml_dump_other_changelog(xmlNodePtr root, cr_Package *package)
 }
 
 
-void
+static void
 cr_xml_dump_other_items(xmlNodePtr root, cr_Package *package)
 {
     /***********************************

--- a/src/xml_dump_repomd.c
+++ b/src/xml_dump_repomd.c
@@ -30,7 +30,7 @@
 #include "xml_dump_internal.h"
 
 
-void
+static void
 cr_xml_dump_repomd_record(xmlNodePtr root, cr_RepomdRecord *rec)
 {
     xmlNodePtr data, node;
@@ -123,7 +123,7 @@ cr_xml_dump_repomd_record(xmlNodePtr root, cr_RepomdRecord *rec)
 }
 
 
-void
+static void
 cr_xml_dump_repomd_body(xmlNodePtr root, cr_Repomd *repomd)
 {
     GSList *element;

--- a/src/xml_dump_updateinfo.c
+++ b/src/xml_dump_updateinfo.c
@@ -32,7 +32,7 @@
 #define ERR_DOMAIN      CREATEREPO_C_ERROR
 #define INDENT          2
 
-void
+static void
 cr_xml_dump_updatecollectionpackages(xmlNodePtr collection, GSList *packages)
 {
     for (GSList *elem = packages; elem; elem = g_slist_next(elem)) {
@@ -69,7 +69,7 @@ cr_xml_dump_updatecollectionpackages(xmlNodePtr collection, GSList *packages)
     }
 }
 
-void
+static void
 cr_xml_dump_updatecollectionmodule(xmlNodePtr collection, cr_UpdateCollectionModule *module)
 {
     if (!module)
@@ -87,7 +87,7 @@ cr_xml_dump_updatecollectionmodule(xmlNodePtr collection, cr_UpdateCollectionMod
     cr_xmlNewProp_c(xml_module, BAD_CAST "arch", BAD_CAST module->arch);
 }
 
-void
+static void
 cr_xml_dump_updateinforecord_pkglist(xmlNodePtr update, GSList *collections)
 {
     xmlNodePtr pkglist;
@@ -111,7 +111,7 @@ cr_xml_dump_updateinforecord_pkglist(xmlNodePtr update, GSList *collections)
     }
 }
 
-void
+static void
 cr_xml_dump_updateinforecord_references(xmlNodePtr update, GSList *refs)
 {
     xmlNodePtr references;
@@ -129,7 +129,7 @@ cr_xml_dump_updateinforecord_references(xmlNodePtr update, GSList *refs)
     }
 }
 
-xmlNodePtr
+static xmlNodePtr
 cr_xml_dump_updateinforecord_internal(xmlNodePtr root, cr_UpdateRecord *rec)
 {
     xmlNodePtr update, node;
@@ -182,7 +182,7 @@ cr_xml_dump_updateinforecord_internal(xmlNodePtr root, cr_UpdateRecord *rec)
 }
 
 
-void
+static void
 cr_xml_dump_updateinfo_body(xmlNodePtr root, cr_UpdateInfo *ui)
 {
     GSList *element;

--- a/src/xml_file.c
+++ b/src/xml_file.c
@@ -119,7 +119,7 @@ cr_xmlfile_set_num_of_pkgs(cr_XmlFile *f, long num, GError **err)
     return CRE_OK;
 }
 
-int
+static int
 cr_xmlfile_write_xml_header(cr_XmlFile *f, GError **err)
 {
     const char *xml_header;
@@ -166,7 +166,7 @@ cr_xmlfile_write_xml_header(cr_XmlFile *f, GError **err)
     return cr_end_chunk(f->f, err);
 }
 
-int
+static int
 cr_xmlfile_write_xml_footer(cr_XmlFile *f, GError **err)
 {
     const char *xml_footer;

--- a/src/xml_parser.c
+++ b/src/xml_parser.c
@@ -29,7 +29,7 @@
 #define ERR_DOMAIN      CREATEREPO_C_ERROR
 
 
-cr_ParserData *
+__attribute__ ((visibility("hidden"))) cr_ParserData *
 cr_xml_parser_data(unsigned int numstates)
 {
     cr_ParserData *pd = g_new0(cr_ParserData, 1);
@@ -41,7 +41,7 @@ cr_xml_parser_data(unsigned int numstates)
     return pd;
 }
 
-void
+__attribute__ ((visibility("hidden"))) void
 cr_xml_parser_data_free(cr_ParserData *pd)
 {
     if (!pd) {
@@ -56,7 +56,7 @@ cr_xml_parser_data_free(cr_ParserData *pd)
     g_free(pd);
 }
 
-void
+__attribute__ ((visibility("hidden"))) void
 cr_char_handler(void *pdata, const xmlChar *s, int len)
 {
     int l;
@@ -82,7 +82,7 @@ cr_char_handler(void *pdata, const xmlChar *s, int len)
     *c = '\0';
 }
 
-int
+__attribute__ ((visibility("hidden"))) int
 cr_xml_parser_warning(cr_ParserData *pd,
                       cr_XmlParserWarningType type,
                       const char *msg,
@@ -121,7 +121,7 @@ cr_xml_parser_warning(cr_ParserData *pd,
     return ret;
 }
 
-gint64
+__attribute__ ((visibility("hidden"))) gint64
 cr_xml_parser_strtoll(cr_ParserData *pd,
                       const char *nptr,
                       unsigned int base)
@@ -147,7 +147,7 @@ cr_xml_parser_strtoll(cr_ParserData *pd,
     return val;
 }
 
-int
+__attribute__ ((visibility("hidden"))) int
 cr_newpkgcb(cr_Package **pkg,
             G_GNUC_UNUSED const char *pkgId,
             G_GNUC_UNUSED const char *name,
@@ -163,7 +163,7 @@ cr_newpkgcb(cr_Package **pkg,
     return CR_CB_RET_OK;
 }
 
-int
+__attribute__ ((visibility("hidden"))) int
 cr_xml_parser_generic(xmlParserCtxtPtr parser,
                       cr_ParserData *pd,
                       const char *path,
@@ -240,7 +240,7 @@ cr_xml_parser_generic(xmlParserCtxtPtr parser,
     return ret;
 }
 
-int
+__attribute__ ((visibility("hidden"))) int
 cr_xml_parser_generic_from_string(xmlParserCtxtPtr parser,
                                   cr_ParserData *pd,
                                   const char *xml_string,
@@ -293,7 +293,7 @@ cr_xml_parser_generic_from_string(xmlParserCtxtPtr parser,
     return ret;
 }
 
-const xmlChar **
+__attribute__ ((visibility("hidden"))) const xmlChar **
 unescape_ampersand_from_values(const xmlChar **attr, gboolean *allocation_needed) {
     *allocation_needed = FALSE;
 

--- a/src/xml_parser_filelists.c
+++ b/src/xml_parser_filelists.c
@@ -318,7 +318,7 @@ cr_end_handler(void *pdata, G_GNUC_UNUSED const xmlChar *element)
     }
 }
 
-cr_ParserData *
+__attribute__ ((visibility("hidden"))) cr_ParserData *
 filelists_parser_data_new(cr_XmlParserNewPkgCb newpkgcb,
                           void *newpkgcb_data,
                           cr_XmlParserPkgCb pkgcb,
@@ -359,7 +359,7 @@ filelists_parser_data_new(cr_XmlParserNewPkgCb newpkgcb,
     return pd;
 }
 
-int
+static int
 cr_xml_parse_filelists_internal(const char *target,
                                 cr_XmlParserNewPkgCb newpkgcb,
                                 void *newpkgcb_data,

--- a/src/xml_parser_other.c
+++ b/src/xml_parser_other.c
@@ -284,7 +284,7 @@ cr_end_handler(void *pdata, G_GNUC_UNUSED const xmlChar *element)
     }
 }
 
-cr_ParserData *
+__attribute__ ((visibility("hidden"))) cr_ParserData *
 other_parser_data_new(cr_XmlParserNewPkgCb newpkgcb,
                       void *newpkgcb_data,
                       cr_XmlParserPkgCb pkgcb,
@@ -325,7 +325,7 @@ other_parser_data_new(cr_XmlParserNewPkgCb newpkgcb,
     return pd;
 }
 
-int
+static int
 cr_xml_parse_other_internal(const char *target,
                             cr_XmlParserNewPkgCb newpkgcb,
                             void *newpkgcb_data,

--- a/src/xml_parser_primary.c
+++ b/src/xml_parser_primary.c
@@ -665,7 +665,7 @@ cr_end_handler(void *pdata, G_GNUC_UNUSED const xmlChar *element)
     }
 }
 
-cr_ParserData *
+__attribute__ ((visibility("hidden"))) cr_ParserData *
 primary_parser_data_new(cr_XmlParserNewPkgCb newpkgcb,
                         void *newpkgcb_data,
                         cr_XmlParserPkgCb pkgcb,
@@ -708,7 +708,7 @@ primary_parser_data_new(cr_XmlParserNewPkgCb newpkgcb,
     return pd;
 }
 
-int
+static int
 cr_xml_parse_primary_internal(const char *target,
                               cr_XmlParserNewPkgCb newpkgcb,
                               void *newpkgcb_data,


### PR DESCRIPTION
The library exported 274 symbols. However, many of them were not declared in any public header file, hence application were not supposed to use them. In other words, the library offered functions which were not part of an API. That was not good because:

These private functions enlarged an attack surface. These private functions polluted binary interface and triggered warnigs by ABI checkers (e.g. when libXML-2.12.0 changed xmlParserCtxt structure).
These private functions could fool a user into calling them and that would increase a pressure on broadening createrepo_c API.

I reviewed all the 274 symbols and hid 52 of them:

cr_char_handler
cr_cktype_from_zck
cr_db_add_filelists_pkg
cr_db_add_other_pkg
cr_db_add_primary_pkg
cr_db_destroy_filelists_statements
cr_db_destroy_other_statements
cr_db_destroy_primary_statements
cr_db_prepare_filelists_statements
cr_db_prepare_other_statements
cr_db_prepare_primary_statements
cr_destroy_metadata_hashtable
cr_free_values
cr_get_compressed_content_stat
cr_new_metadata_hashtable
cr_newpkgcb
cr_package_copy_into
cr_prestodeltatask_free
cr_remove_dir_cb
cr_xml_dump_delta
cr_xml_dump_filelists_chunk
cr_xml_dump_filelists_items
cr_xml_dump_files
cr_xml_dump_int
cr_xml_dump_other_changelog
cr_xml_dump_other_items
cr_xml_dump_repomd_body
cr_xml_dump_repomd_record
cr_xml_dump_updatecollectionmodule
cr_xml_dump_updatecollectionpackages
cr_xml_dump_updateinfo_body
cr_xml_dump_updateinforecord_internal
cr_xml_dump_updateinforecord_pkglist
cr_xml_dump_updateinforecord_references
cr_xmlfile_write_xml_footer
cr_xmlfile_write_xml_header
cr_xmlNewProp
cr_xmlNewTextChild
cr_xml_parse_filelists_internal
cr_xml_parse_other_internal
cr_xml_parse_primary_internal
cr_xml_parser_data
cr_xml_parser_data_free
cr_xml_parser_generic
cr_xml_parser_generic_from_string
cr_xml_parser_strtoll
cr_xml_parser_warning
filelists_parser_data_new
other_parser_data_new
prepare_split_media_baseurl
primary_parser_data_new
unescape_ampersand_from_values

I kept these 10 private symbols because they are called either from createrepo_c program or from a Python binding:

cr_compress_groupfile
cr_delayed_dump_run
cr_delayed_dump_set
cr_distrotag_new
cr_dumper_thread
cr_metadata_load_modulemd
cr_metadata_modulemd
cr_repomd_compare
cr_xml_dump_primary_base_items
cr_xml_dump_primary_dump_pco

This patch minimizes a symbol table by making the private functions static or by setting their visibility to a hidden state. As result, they disappear from the library binary interface.