### PR TITLE
Fix const-correctness with libxml2-2.12.0

### DIFF
--- a/src/xml_parser.c
+++ b/src/xml_parser.c
@@ -201,7 +201,7 @@ cr_xml_parser_generic(xmlParserCtxtPtr parser,
 
         if (xmlParseChunk(parser, buf, len, len == 0)) {
             ret = CRE_XMLPARSER;
-            xmlErrorPtr xml_err = xmlCtxtGetLastError(parser);
+            const xmlError *xml_err = xmlCtxtGetLastError(parser);
             g_critical("%s: parsing error '%s': %s",
                        __func__,
                        path,
@@ -272,7 +272,7 @@ cr_xml_parser_generic_from_string(xmlParserCtxtPtr parser,
 
         if (xmlParseChunk(parser, data, block_size, finished)) {
             ret = CRE_XMLPARSER;
-            xmlErrorPtr xml_err = xmlCtxtGetLastError(parser);
+            const xmlError *xml_err = xmlCtxtGetLastError(parser);
             g_critical("%s: parsing error '%s': %s",
                        __func__,
                        data,

--- a/src/xml_parser_main_metadata_together.c
+++ b/src/xml_parser_main_metadata_together.c
@@ -298,7 +298,7 @@ parse_next_section(CR_FILE *target_file, const char *path, cr_ParserData *pd, GE
     }
     int done = parsed_len == 0;
     if (xmlParseChunk(pd->parser, buf, parsed_len, done)) {
-        xmlErrorPtr xml_err = xmlCtxtGetLastError(pd->parser);
+        const xmlError *xml_err = xmlCtxtGetLastError(pd->parser);
         g_critical("%s: parsing error '%s': %s", __func__, path,
                    (xml_err) ? xml_err->message : "UNKNOWN_ERROR");
         g_set_error(err, ERR_DOMAIN, CRE_XMLPARSER,


### PR DESCRIPTION
libxml2-2.12.0 started to return errors as a pointer to a constant structure and GCC 13.2.1 started to warn like this:

/home/test/createrepo_c/src/xml_parser.c: In function ‘cr_xml_parser_generic’: /home/test/createrepo_c/src/xml_parser.c:204:35: warning: initialization discards ‘const’ qualifier fro m pointer target type [-Wdiscarded-qualifiers]
  204 |             xmlErrorPtr xml_err = xmlCtxtGetLastError(parser);
      |                                   ^~~~~~~~~~~~~~~~~~~

This patch fixes it.