### PR TITLE
Use a gzip compression by default when --compatibility is specified

### DIFF
--- a/doc/createrepo_c.8
+++ b/doc/createrepo_c.8
@@ -182,7 +182,7 @@ Keep all additional metadata (not primary, filelists and other xml or sqlite fil
 Discard all additional metadata (not primary, filelists and other xml or sqlite files, nor their compressed variants) from source repository during update.
 .SS \-\-compatibility
 .sp
-Enforce maximal compatibility with classical createrepo (Affects only: \-\-retain\-old\-md).
+Enforce maximal compatibility with classical createrepo (Changes \-\-retain\-old\-md behavior, uses Gzip for compression).
 .SS \-\-retain\-old\-md\-by\-age AGE
 .sp
 During \-\-update, remove all files in repodata/ which are older then the specified period of time. (e.g. \(aq2h\(aq, \(aq30d\(aq, ...). Available units (m \- minutes, h \- hours, d \- days)

--- a/src/cmd_parser.c
+++ b/src/cmd_parser.c
@@ -200,7 +200,7 @@ static GOptionEntry cmd_entries[] =
       "Discard all additional metadata (not primary, filelists and other xml or sqlite files, "
       "nor their compressed variants) from source repository during update.", NULL },
     { "compatibility", 0, 0, G_OPTION_ARG_NONE, &(_cmd_options.compatibility),
-      "Enforce maximal compatibility with classical createrepo (Affects only: --retain-old-md).", NULL },
+      "Enforce maximal compatibility with classical createrepo (Changes --retain-old-md behavior, uses Gzip for compression).", NULL },
     { "retain-old-md-by-age", 0, 0, G_OPTION_ARG_STRING, &(_cmd_options.retain_old_md_by_age),
       "During --update, remove all files in repodata/ which are older "
       "then the specified period of time. (e.g. '2h', '30d', ...). "

--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -831,6 +831,11 @@ main(int argc, char **argv)
     cr_CompressionType sqlite_compression = CR_CW_BZ2_COMPRESSION;
     cr_CompressionType compression = CR_CW_ZSTD_COMPRESSION;
 
+    if (cmd_options->compatibility) {
+        xml_compression    = CR_CW_GZ_COMPRESSION;
+        compression        = CR_CW_GZ_COMPRESSION;
+    }
+
     if (cmd_options->compression_type != CR_CW_UNKNOWN_COMPRESSION) {
         sqlite_compression = cmd_options->compression_type;
         compression        = cmd_options->compression_type;


### PR DESCRIPTION
Unless the user explicitly asks for a different compression algo.