### PR TITLE
Default changelog limit restored for --compatibility

### DIFF
--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -1445,11 +1445,7 @@ main(int argc, char **argv)
     user_data.fil_zck           = fil_cr_zck;
     user_data.fex_zck           = fex_cr_zck;
     user_data.oth_zck           = oth_cr_zck;
-    if (cmd_options->compatibility && cmd_options->changelog_limit == DEFAULT_CHANGELOG_LIMIT ) {
-      user_data.changelog_limit = -1;
-    } else {
-      user_data.changelog_limit = cmd_options->changelog_limit;
-    }
+    user_data.changelog_limit = cmd_options->changelog_limit;
     user_data.location_base     = cmd_options->location_base;
     user_data.checksum_type_str = cr_checksum_name_str(cmd_options->checksum_type);
     user_data.checksum_type     = cmd_options->checksum_type;


### PR DESCRIPTION
Defaulting to keeping all changelogs, while accurate to the behavior of legacy createrepo, can result in terrible behaviors for some repositories, making them potentially too large to be usable (libsolv may segfault, I'm not sure about YUM, but both end up unpacking the data on the root partition potentially causing it to run out of space).

The most problematic packages are ones like openssl, glibc, and the kernel which ship with 20+ years of changelog history.  If the repo contains many versions of these packages, the impact is tremendous.  If a user needs full changelog history, they ought to consult `rpm --qa --changelog`

This behavior of the --compatibility flag was never explicitly documented.

closes #318