### PR TITLE
Extend the --compatibility flag to cover other defaults

### DIFF
--- a/src/cmd_parser.c
+++ b/src/cmd_parser.c
@@ -204,7 +204,7 @@ static GOptionEntry cmd_entries[] =
       "Discard all additional metadata (not primary, filelists and other xml or sqlite files, "
       "nor their compressed variants) from source repository during update.", NULL },
     { "compatibility", 0, 0, G_OPTION_ARG_NONE, &(_cmd_options.compatibility),
-      "Enforce maximal compatibility with classical createrepo (Changes --retain-old-md behavior, uses Gzip for compression, produces sqlite metadata by default).", NULL },
+      "Enforce maximal compatibility with classical createrepo and yum (Changes --retain-old-md behavior, uses Gzip for compression, produces sqlite metadata by default, leaves group metadata uncompressed).", NULL },
     { "retain-old-md-by-age", 0, 0, G_OPTION_ARG_STRING, &(_cmd_options.retain_old_md_by_age),
       "During --update, remove all files in repodata/ which are older "
       "then the specified period of time. (e.g. '2h', '30d', ...). "

--- a/src/cmd_parser.c
+++ b/src/cmd_parser.c
@@ -204,7 +204,7 @@ static GOptionEntry cmd_entries[] =
       "Discard all additional metadata (not primary, filelists and other xml or sqlite files, "
       "nor their compressed variants) from source repository during update.", NULL },
     { "compatibility", 0, 0, G_OPTION_ARG_NONE, &(_cmd_options.compatibility),
-      "Enforce maximal compatibility with classical createrepo (Changes --retain-old-md behavior, uses Gzip for compression).", NULL },
+      "Enforce maximal compatibility with classical createrepo (Changes --retain-old-md behavior, uses Gzip for compression, produces sqlite metadata by default).", NULL },
     { "retain-old-md-by-age", 0, 0, G_OPTION_ARG_STRING, &(_cmd_options.retain_old_md_by_age),
       "During --update, remove all files in repodata/ which are older "
       "then the specified period of time. (e.g. '2h', '30d', ...). "

--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -1143,7 +1143,9 @@ main(int argc, char **argv)
     cr_SqliteDb *fex_db = NULL;
     cr_SqliteDb *oth_db = NULL;
 
-    if (cmd_options->database) {
+    gboolean should_create_databases = cmd_options->database || (cmd_options->compatibility && !cmd_options->no_database);
+
+    if (should_create_databases) {
         _cleanup_file_close_ int pri_db_fd = -1;
         _cleanup_file_close_ int fil_db_fd = -1;
         _cleanup_file_close_ int fex_db_fd = -1;
@@ -1826,8 +1828,7 @@ main(int argc, char **argv)
     cr_repomdrecordfilltask_free(oth_fill_task, NULL);
 
     // Sqlite db
-    if (cmd_options->database) {
-
+    if (should_create_databases) {
         gchar *pri_db_name = g_strconcat(tmp_out_repo, "/primary.sqlite",
                                          sqlite_compression_suffix, NULL);
         gchar *fil_db_name = g_strconcat(tmp_out_repo, "/filelists.sqlite",

--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -853,7 +853,12 @@ main(int argc, char **argv)
 
     // Groupfile specified as argument
     if (cmd_options->groupfile_fullpath) {
-        gchar *compressed_path = cr_compress_groupfile(cmd_options->groupfile_fullpath, tmp_out_repo, compression);
+        cr_CompressionType group_compression = compression;
+        // Skip compressing the group metadata when using --compatibility flag
+        if (cmd_options->compatibility) {
+            group_compression = CR_CW_NO_COMPRESSION;
+        }
+        gchar *compressed_path = cr_compress_groupfile(cmd_options->groupfile_fullpath, tmp_out_repo, group_compression);
         cr_Metadatum *new_groupfile_metadatum = g_malloc0(sizeof(cr_Metadatum));
         new_groupfile_metadatum->name = compressed_path;
         new_groupfile_metadatum->type = g_strdup("group");


### PR DESCRIPTION
* --compatibility will enable sqlite metadata by default
* --compatibility will leave group metadata uncompressed rather than defaulting to the same compression as everything else

I believe this covers the bases in terms of ensuring createrepo_c 1.0 can still generate repos consumable by ancient RHEL / SUSE without too much effort.

I don't add  `group_gz` (separate gzip-compressed group metadata) back - this is aiming for minimal additional complexity and `group_gz` simply isn't worth it.  It's usually a relatively tiny metadata file anyway.