### PR TITLE
Use compatibility for createrepo

### DIFF
--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -634,6 +634,11 @@ main(int argc, char **argv)
         }
     }
 
+    // Using createrepo assumes compatibility mode
+    if (!g_strcmp0(g_path_get_basename(argv[0]),"createrepo")) {
+        cmd_options->compatibility=TRUE;
+    }
+
     // Dirs
     gchar *in_dir       = NULL;  // path/to/repo/
     gchar *in_repo      = NULL;  // path/to/repo/repodata/


### PR DESCRIPTION
Reported as #403

The point of using createrepo is to keep the same behavior with the createrepo command. Users that want modern behavior should use createrepo_c command instead.