### PR TITLE
Fix a file descriptor and memory leak in an error path of cr_detect_compression()

### DIFF
--- a/src/compression_wrapper.c
+++ b/src/compression_wrapper.c
@@ -190,13 +190,13 @@ cr_detect_compression(const char *filename, GError **err)
     }
 
     size_t bytesRead = fread(magic, 1, sizeof(magic), file);
+    fclose(file);
     if (bytesRead != sizeof(magic)) {
         // Assume that if there's less than 5 bytes in the file, it's uncompressed
         g_debug("%s: Unable to read bytes from file for magic number detection, assuming uncompressed (%s)",
             __func__, filename);
         return CR_CW_NO_COMPRESSION;
     }
-    fclose(file);
 
     if (!memcmp(magic, "\x1F\x8B", 2)) {
         return CR_CW_GZ_COMPRESSION;


### PR DESCRIPTION
Covscan reported:

    createrepo_c-1.1.2/src/compression_wrapper.c:197: error[resourceLeak]: Resource leak: file

It's a real bug and this patch fixes it.

Resolves: https://issues.redhat.com/browse/RHEL-45645