### PR TITLE
Include unistd.h for STDOUT_FILENO

### DIFF
--- a/src/compression_wrapper.c
+++ b/src/compression_wrapper.c
@@ -31,6 +31,7 @@
 #include <lzma.h>
 #ifdef WITH_ZCHUNK
 #include <zck.h>
+#include <unistd.h>
 #endif  // WITH_ZCHUNK
 #include "error.h"
 #include "compression_wrapper.h"


### PR DESCRIPTION
STDOUT_FILENO is defined in unistd.h, see [POSIX](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/unistd.h.html).

This is required on FreeBSD.