### PR TITLE
Allow incremental parsing without filelists or other xml

### DIFF
--- a/src/python/createrepo_c/__init__.py
+++ b/src/python/createrepo_c/__init__.py
@@ -416,8 +416,8 @@ class RepositoryReader:
         metadata_files = {record.type: record for record in repomd.records}
         parser = RepositoryReader()
         parser._primary_xml_path = os.path.join(path, metadata_files["primary"].location_href)
-        parser._filelists_xml_path = os.path.join(path, metadata_files["filelists"].location_href)
-        parser._other_xml_path = os.path.join(path, metadata_files["other"].location_href)
+        parser._filelists_xml_path = os.path.join(path, metadata_files["filelists"].location_href) if metadata_files.get("filelists") else None
+        parser._other_xml_path = os.path.join(path, metadata_files["other"].location_href) if metadata_files.get("other") else None
 
         if metadata_files.get("updateinfo"):
             parser._updateinfo_path = os.path.join(path, metadata_files["updateinfo"].location_href)

--- a/src/python/xml_parser-py.c
+++ b/src/python/xml_parser-py.c
@@ -780,14 +780,14 @@ pkg_iterator_init(_PkgIteratorObject *self, PyObject *args, PyObject *kwargs)
     static char *kwlist[] = {"primary", "filelists", "other", "newpkgcb",
                              "warningcb", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "sssOO:pkg_iterator_init", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "szzOO:pkg_iterator_init", kwlist,
                                      &primary_path, &filelists_path, &other_path, &py_newpkgcb,
                                      &py_warningcb)) {
         return -1;
     }
 
-    if (!primary_path || !filelists_path || !other_path) {
-        PyErr_SetString(PyExc_TypeError, "file paths must be provided");
+    if (!primary_path) {
+        PyErr_SetString(PyExc_TypeError, "primary file path must be provided");
         return -1;
     }
 

--- a/tests/python/tests/test_xml_parser.py
+++ b/tests/python/tests/test_xml_parser.py
@@ -1245,6 +1245,74 @@ class TestCaseXmlParserPkgIterator(unittest.TestCase):
         self.assertRaises(StopIteration, next, package_iterator)
         self.assertTrue(package_iterator.is_finished())
 
+    def test_xml_parser_pkg_iterator_repo02_only_primary(self):
+        warnings = []
+        def warningcb(warn_type, msg):
+            warnings.append((warn_type, msg))
+
+        package_iterator = cr.PackageIterator(
+            primary_path=REPO_02_PRIXML, filelists_path=None, other_path=None,
+            warningcb=warningcb,
+        )
+        packages = list(package_iterator)
+
+        self.assertEqual(len(packages), 2)
+        self.assertEqual(packages[0].name, "fake_bash")
+        self.assertEqual(packages[0].files, [(None, '/usr/bin/', 'fake_bash')])  # the files still get parsed - only from primary.xml
+        self.assertEqual(packages[0].changelogs, [])
+        self.assertListEqual(warnings, [])
+        self.assertRaises(StopIteration, next, package_iterator)
+        self.assertTrue(package_iterator.is_finished())
+
+
+    def test_xml_parser_pkg_iterator_repo02_no_primary(self):
+        def test():
+            cr.PackageIterator(
+                primary_path=None, filelists_path=REPO_02_FILXML, other_path=REPO_02_OTHXML,
+            )
+
+        self.assertRaises(TypeError, test)
+
+    def test_xml_parser_pkg_iterator_repo02_no_filelists(self):
+        warnings = []
+        def warningcb(warn_type, msg):
+            warnings.append((warn_type, msg))
+
+        package_iterator = cr.PackageIterator(
+            primary_path=REPO_02_PRIXML, filelists_path=None, other_path=REPO_02_OTHXML,
+            warningcb=warningcb,
+        )
+        packages = list(package_iterator)
+
+        self.assertEqual(len(packages), 2)
+        self.assertEqual(packages[0].name, "fake_bash")
+        self.assertEqual(packages[0].changelogs, [
+            ('Tomas Mlcoch <tmlcoch@redhat.com> - 1.1.1-1', 1334664000, '- First release'),
+        ])
+        self.assertEqual(packages[0].files, [(None, '/usr/bin/', 'fake_bash')])  # the files still get parsed - only from primary.xml
+        self.assertListEqual(warnings, [])
+        self.assertRaises(StopIteration, next, package_iterator)
+        self.assertTrue(package_iterator.is_finished())
+
+    def test_xml_parser_pkg_iterator_repo02_no_other(self):
+        warnings = []
+        def warningcb(warn_type, msg):
+            warnings.append((warn_type, msg))
+
+        package_iterator = cr.PackageIterator(
+            primary_path=REPO_02_PRIXML, filelists_path=REPO_02_FILXML, other_path=None,
+            warningcb=warningcb,
+        )
+        packages = list(package_iterator)
+
+        self.assertEqual(len(packages), 2)
+        self.assertEqual(packages[0].name, "fake_bash")
+        self.assertEqual(packages[0].changelogs, [])
+        self.assertEqual(packages[0].files, [(None, '/usr/bin/', 'fake_bash')])
+        self.assertListEqual(warnings, [])
+        self.assertRaises(StopIteration, next, package_iterator)
+        self.assertTrue(package_iterator.is_finished())
+
     def test_xml_parser_pkg_iterator_repo02_newpkgcb_as_filter(self):
         def newpkgcb(pkgId, name, arch):
             if name in {"fake_bash"}:

--- a/tests/test_xml_parser_main_metadata_together.c
+++ b/tests/test_xml_parser_main_metadata_together.c
@@ -121,6 +121,50 @@ test_cr_xml_package_iterator_00(void)
 }
 
 static void
+test_cr_xml_package_iterator_00_no_filelists(void)
+{
+    int parsed = 0;
+    GError *tmp_err = NULL;
+    cr_Package *package = NULL;
+
+    cr_PkgIterator *pkg_iterator = cr_PkgIterator_new(
+        TEST_REPO_02_PRIMARY, NULL, TEST_REPO_02_OTHER, NULL, NULL, NULL, NULL, &tmp_err);
+
+    while ((package = cr_PkgIterator_parse_next(pkg_iterator, &tmp_err))) {
+        parsed++;
+        cr_package_free(package);
+    }
+
+    g_assert(cr_PkgIterator_is_finished(pkg_iterator));
+    cr_PkgIterator_free(pkg_iterator, &tmp_err);
+
+    g_assert(tmp_err == NULL);
+    g_assert_cmpint(parsed, ==, 2);
+}
+
+static void
+test_cr_xml_package_iterator_00_no_other(void)
+{
+    int parsed = 0;
+    GError *tmp_err = NULL;
+    cr_Package *package = NULL;
+
+    cr_PkgIterator *pkg_iterator = cr_PkgIterator_new(
+        TEST_REPO_02_PRIMARY, TEST_REPO_02_FILELISTS, NULL, NULL, NULL, NULL, NULL, &tmp_err);
+
+    while ((package = cr_PkgIterator_parse_next(pkg_iterator, &tmp_err))) {
+        parsed++;
+        cr_package_free(package);
+    }
+
+    g_assert(cr_PkgIterator_is_finished(pkg_iterator));
+    cr_PkgIterator_free(pkg_iterator, &tmp_err);
+
+    g_assert(tmp_err == NULL);
+    g_assert_cmpint(parsed, ==, 2);
+}
+
+static void
 test_cr_xml_package_iterator_filelists_ext_00(void)
 {
     int parsed = 0;
@@ -319,6 +363,12 @@ main(int argc, char *argv[])
 
     g_test_add_func("/xml_parser_main_metadata/test_cr_xml_package_iterator_00",
                     test_cr_xml_package_iterator_00);
+
+    g_test_add_func("/xml_parser_main_metadata/test_cr_xml_package_iterator_00_no_filelists",
+                    test_cr_xml_package_iterator_00_no_filelists);
+
+    g_test_add_func("/xml_parser_main_metadata/test_cr_xml_package_iterator_00_no_other",
+                    test_cr_xml_package_iterator_00_no_other);
 
     g_test_add_func("/xml_parser_main_metadata/test_cr_xml_package_iterator_filelists_ext_00",
                     test_cr_xml_package_iterator_filelists_ext_00);


### PR DESCRIPTION
Supplying a NULL value as a filelists or other "path" argument ought to work.  But primary metadata is always required.

closes #423