### PR TITLE
Remove LEGACY_HASHES override from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ setup(
         '-DENABLE_BASHCOMP:BOOL=OFF',
         '-DENABLE_DRPM:BOOL=OFF',
         '-DWITH_ZCHUNK:BOOL=OFF',
-        '-DWITH_LEGACY_HASHES:BOOL=ON',
     ],
     cmake_languages=['C'],
     entry_points={


### PR DESCRIPTION
Pulp needed this overridden at one point, but not anymore.