### PR TITLE
cmake: Allow builds without Doxygen being present with CMake 4+

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,3 +11,4 @@ Ralph Bean <rbean@redhat.com>
 Frank Schreiner <schreiner@suse.de>
 Daniel Alley <dalley@redhat.com>
 Matt Jolly <matt.jolly@footclan.ninja>
+Moritz Haase <moritz.haase at bmw dot de>

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,11 +1,15 @@
 ADD_SUBDIRECTORY (python)
 
+ADD_CUSTOM_TARGET (doc)
+ADD_DEPENDENCIES (doc doc-python)
+
 find_package(Doxygen)
 if(DOXYGEN_FOUND)
     CONFIGURE_FILE("Doxyfile.in.in" "${CMAKE_CURRENT_BINARY_DIR}/Doxyfile.in" @ONLY)
     add_custom_target(doc-c
         ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile.in
         COMMENT "Building C API documentation with Doxygen" VERBATIM)
+    ADD_DEPENDENCIES (doc doc-c)
 endif(DOXYGEN_FOUND)
 
 IF(CREATEREPO_C_INSTALL_MANPAGES)
@@ -13,6 +17,3 @@ IF(CREATEREPO_C_INSTALL_MANPAGES)
             DESTINATION "${CMAKE_INSTALL_MANDIR}/man8"
             COMPONENT bin)
 ENDIF(CREATEREPO_C_INSTALL_MANPAGES)
-
-ADD_CUSTOM_TARGET (doc)
-ADD_DEPENDENCIES (doc doc-python doc-c)


### PR DESCRIPTION
With CMake 4+, the initial CMake run fails with

    CMake Error at doc/CMakeLists.txt:18 (ADD_DEPENDENCIES):
      The dependency target "doc-c" of target "doc" does not exist.

in case Doxygen is not installed on the system, since non-existent dependencies
are not ignored anymore (see [0]). Rectify that by making sure that we only add
the dependency in case Doxygen has been found.

[0]: https://cmake.org/cmake/help/latest/policy/CMP0046.html