### PR TITLE
Use RPMTAG_SHA1HEADER instead of RPMTAG_HDRID

### DIFF
--- a/src/parsehdr.c
+++ b/src/parsehdr.c
@@ -666,7 +666,7 @@ cr_package_from_header(Header hdr,
 
     if (hdrrflags & CR_HDRR_LOADHDRID)
         pkg->hdrid = cr_safe_string_chunk_insert(pkg->chunk,
-                                                 headerGetString(hdr, RPMTAG_HDRID));
+                                                 headerGetString(hdr, RPMTAG_SHA1HEADER));
 
     if (hdrrflags & CR_HDRR_LOADSIGNATURES) {
         rpmtd gpgtd = rpmtdNew();


### PR DESCRIPTION
Building against rpm-5.99.91 failed:

    /home/test/createrepo_c/src/parsehdr.c: In function ‘cr_package_from_header’:
    /home/test/createrepo_c/src/parsehdr.c:669:71: error: ‘RPMTAG_HDRID’ undeclared (first use in this function); did you mean ‘RPMTAG_CVSID’?
      669 |                                                  headerGetString(hdr, RPMTAG_HDRID));
	  |                                                                       ^~~~~~~~~~~~
	  |                                                                       RPMTAG_CVSID

RPM intentionally removed RPMTAG_HDRID tag alias in commit 79ba4a3c41702e46edd5a4ce7e17a1f3361eb0e7 ("Drop irrepairable pkgid and hdrid tag aliases, rename SOURCEPKGID to go").

This patch fixes building against RPMv6 by using RPMTAG_SHA1HEADER which RPMTAG_HDRID was aliased to. RPMTAG_SHA1HEADER has existed in RPM since the year 2001. RPMTAG_HDRID was an alias to RPMTAG_SHA1HEADER all the time RPMTAG_HDRID existed.

In the features we should look for another digest header RPMv6 packages will use.