### PR TITLE
Avoid stat as struct member name to prevent macro conflicts on AIX

### DIFF
--- a/src/parsehdr.c
+++ b/src/parsehdr.c
@@ -24,7 +24,11 @@
 #include <rpm/rpmpgp.h>
 #include <rpm/rpmtag.h>
 #include <rpm/rpmtd.h>
+#ifdef _AIX
+#include <rpm/rpmds.h>
+#else
 #include <rpm/rpmver.h>
+#endif
 #include <stdlib.h>
 #include "parsehdr.h"
 #include "xml_dump.h"


### PR DESCRIPTION
Hi All,

While building createrepo_c on AIX with large file support, we encountered a compilation issue caused by a name collision between a struct member and a system macro.

In threads.h, the cr_CompressionTask struct currently has a member:

`cr_ContentStat *stat;`

On AIX, D_LARGE_FILES defines the macro:

`#define stat stat64`

During compilation, any use of task->stat in the code gets preprocessed to task->stat64, which does not exist in the struct, resulting in errors like:

```
[ 25%] Building C object src/CMakeFiles/libcreaterepo_c.dir/threads.c.o
cd /opt/freeware/src/packages/BUILD/createrepo_c-1.2.1/build-py3/src && /opt/freeware/bin/gcc -DENABLE_LEGACY_WEAKDEPS=1 -DG_LOG_DOMAIN=\"C_CREATEREPOLIB\" -Dlibcreaterepo_c_EXPORTS -I/opt/freeware/src/packages/BUILD/createrepo_c-1.2.1 -I/opt/freeware/include/glib-2.0 -I/opt/freeware/lib/glib-2.0/include -I/opt/freeware/include/libxml2 -fPIC -fpermissive -D_ALL_SOURCE -D_LARGE_FILES -D_XOPEN_SOURCE=700 -static-libgcc -static-libstdc++ -std=gnu99 -O2 -g -DNDEBUG -fPIC -MD -MT src/CMakeFiles/libcreaterepo_c.dir/threads.c.o -MF CMakeFiles/libcreaterepo_c.dir/threads.c.o.d -o CMakeFiles/libcreaterepo_c.dir/threads.c.o -c /opt/freeware/src/packages/BUILD/createrepo_c-1.2.1/src/threads.c
cc1: warning: command-line option '-fpermissive' is valid for C++/ObjC++ but not for C
In file included from /usr/include/rpm/rpmio.h:11,
                 from /usr/include/rpm/rpmlib.h:11,
                 from /opt/freeware/src/packages/BUILD/createrepo_c-1.2.1/src/dumper_thread.h:28,
                 from /opt/freeware/src/packages/BUILD/createrepo_c-1.2.1/src/threads.c:24:
/opt/freeware/src/packages/BUILD/createrepo_c-1.2.1/src/threads.c: In function 'cr_compressiontask_new':
/opt/freeware/src/packages/BUILD/createrepo_c-1.2.1/src/threads.c:64:11: error: 'cr_CompressionTask' has no member named 'stat64'; did you mean 'stat'?
   64 |     task->stat   = stat;
      |           ^~~~
/opt/freeware/src/packages/BUILD/createrepo_c-1.2.1/src/threads.c: In function 'cr_compressiontask_free':
/opt/freeware/src/packages/BUILD/createrepo_c-1.2.1/src/threads.c:83:31: error: 'cr_CompressionTask' has no member named 'stat64'; did you mean 'stat'?
   83 |     cr_contentstat_free(task->stat, err);
      |                               ^~~~
/opt/freeware/src/packages/BUILD/createrepo_c-1.2.1/src/threads.c: In function 'cr_compressing_thread':
/opt/freeware/src/packages/BUILD/createrepo_c-1.2.1/src/threads.c:107:38: error: 'cr_CompressionTask' has no member named 'stat64'; did you mean 'stat'?
  107 |                                task->stat,
      |                                      ^~~~
/opt/freeware/src/packages/BUILD/createrepo_c-1.2.1/src/threads.c: In function 'cr_rewrite_pkg_count_thread':
/opt/freeware/src/packages/BUILD/createrepo_c-1.2.1/src/threads.c:135:43: error: 'cr_CompressionTask' has no member named 'stat64'; did you mean 'stat'?
  135 |                                     task->stat,
      |                                           ^~~~
```

**Proposed Fix:**

Rename the struct member to avoid collision with the stat macro, for example:

`cr_ContentStat *stat_crcnt;`

This change avoids macro substitution issues on AIX and does not affect behavior on other platforms.

Please let me know if a different naming convention is preferred.

Thanks.