### PR TITLE
Remove uneeded inclusions of <rpm/rpmlib.h>

### DIFF
--- a/src/deltarpms.h.in
+++ b/src/deltarpms.h.in
@@ -25,7 +25,6 @@ extern "C" {
 #endif
 
 #include <glib.h>
-#include <rpm/rpmlib.h>
 #include "package.h"
 #include "parsehdr.h"
 #include "xml_file.h"

--- a/src/dumper_thread.h
+++ b/src/dumper_thread.h
@@ -25,7 +25,6 @@ extern "C" {
 #endif
 
 #include <glib.h>
-#include <rpm/rpmlib.h>
 #include "load_metadata.h"
 #include "locate_metadata.h"
 #include "misc.h"

--- a/src/misc.c
+++ b/src/misc.c
@@ -25,7 +25,7 @@
 #include <curl/curl.h>
 #include <errno.h>
 #include <ftw.h>
-#include <rpm/rpmlib.h>
+#include <rpm/rpmver.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/parsehdr.c
+++ b/src/parsehdr.c
@@ -19,8 +19,12 @@
 
 #include <glib.h>
 #include <assert.h>
+#include <rpm/header.h>
 #include <rpm/rpmfi.h>
 #include <rpm/rpmpgp.h>
+#include <rpm/rpmtag.h>
+#include <rpm/rpmtd.h>
+#include <rpm/rpmver.h>
 #include <stdlib.h>
 #include "parsehdr.h"
 #include "xml_dump.h"

--- a/src/parsehdr.h
+++ b/src/parsehdr.h
@@ -25,7 +25,7 @@ extern "C" {
 #endif
 
 #include <glib.h>
-#include <rpm/rpmlib.h>
+#include <rpm/rpmtypes.h>
 #include "package.h"
 
 /** \defgroup   parsehdr         Header parser API.

--- a/src/sqlite.c
+++ b/src/sqlite.c
@@ -26,6 +26,7 @@
 #include <assert.h>
 #include <string.h>
 #include <stdlib.h>
+#include <sys/stat.h>
 #include <errno.h>
 #include <libxml/encoding.h>
 #include <libxml/xmlstring.h>


### PR DESCRIPTION
The header file is not actually needed to be included on matny places, especially in public API createrepo_c header files as given files do not use any RPM symbols.