### PR TITLE
Restore compatibility with RPM 4.14.3

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,6 +78,11 @@ IF (NOT HAVE_NFTW)
     ENDIF ()
 ENDIF ()
 
+# rpm/rpmver.h exists since RPM 4.16.0-beta2.
+IF (RPM_VERSION VERSION_GREATER_EQUAL "4.16.0")
+    ADD_COMPILE_DEFINITIONS(HAVE_RPM_RPMVER_H)
+ENDIF ()
+
 IF (BUILD_LIBCREATEREPO_C_SHARED)
   SET (createrepo_c_library_type SHARED)
 ELSE ()

--- a/src/misc.c
+++ b/src/misc.c
@@ -25,7 +25,11 @@
 #include <curl/curl.h>
 #include <errno.h>
 #include <ftw.h>
+#ifdef HAVE_RPM_RPMVER_H
 #include <rpm/rpmver.h>
+#else
+#include <rpm/rpmlib.h>
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/parsehdr.c
+++ b/src/parsehdr.c
@@ -24,7 +24,11 @@
 #include <rpm/rpmpgp.h>
 #include <rpm/rpmtag.h>
 #include <rpm/rpmtd.h>
+#ifdef HAVE_RPM_RPMVER_H
 #include <rpm/rpmver.h>
+#else
+#include <rpm/rpmlib.h>
+#endif
 #include <stdlib.h>
 #include "parsehdr.h"
 #include "xml_dump.h"


### PR DESCRIPTION
Commit 9ff916d5fa738c73bd9ee796d67d29c65b4b7dfb ("Remove uneeded inclusions of <rpm/rpmlib.h>") broke comptability with RPM before 4.16.0-beta2. Building with 4.14.3 failed:

    /tmp/createrepo_c/src/misc.c:28:10: fatal error: rpm/rpmver.h: No such file or directory
     #include <rpm/rpmver.h>
              ^~~~~~~~~~~~~~
This patch restores a compatibility with older rpm versions. Tested with rpm-4.14.3.

(In the future, createrepo_c should define a minimal supported RPM version.)

Relates: #464