### PR TITLE
Package from rpm file digests

### DIFF
--- a/src/parsehdr.c
+++ b/src/parsehdr.c
@@ -321,8 +321,10 @@ cr_package_from_header(Header hdr,
                 packagefile->type = cr_safe_string_chunk_insert(pkg->chunk, "");
             }
 
-            packagefile->digest = cr_safe_string_chunk_insert(pkg->chunk,
-                                                              rpmtdGetString(filedigests));
+            if (!(hdrrflags & CR_HDRR_NOFILEDIGESTS)) {
+                packagefile->digest = cr_safe_string_chunk_insert(pkg->chunk,
+                                                                  rpmtdGetString(filedigests));
+            }
 
             g_hash_table_replace(filenames_hashtable,
                                  (gpointer) rpmtdGetString(full_filenames),

--- a/src/parsehdr.h
+++ b/src/parsehdr.h
@@ -39,6 +39,11 @@ typedef enum {
     CR_HDRR_NONE            = (1 << 0),
     CR_HDRR_LOADHDRID       = (1 << 1), /*!< Load hdrid */
     CR_HDRR_LOADSIGNATURES  = (1 << 2), /*!< Load siggpg and siggpg */
+    CR_HDRR_NOFILEDIGESTS   = (1 << 3), /*!< Don't load file digests */
+    CR_HDRR_ALL             = CR_HDRR_NONE |
+                              CR_HDRR_LOADHDRID |
+                              CR_HDRR_LOADSIGNATURES |
+                              CR_HDRR_NOFILEDIGESTS, /*!< All flags set (doesn't mean load all) */
 } cr_HeaderReadingFlags;
 
 /** Read data from header and return filled cr_Package structure.

--- a/src/python/createrepo_c/__init__.py
+++ b/src/python/createrepo_c/__init__.py
@@ -86,6 +86,11 @@ XMLFILE_OTHER         = _createrepo_c.XMLFILE_OTHER         #: Other xml file
 XMLFILE_PRESTODELTA   = _createrepo_c.XMLFILE_PRESTODELTA   #: Prestodelta xml file
 XMLFILE_UPDATEINFO    = _createrepo_c.XMLFILE_UPDATEINFO    #: Updateinfo xml file
 
+HDRR_NONE           = _createrepo_c.HDRR_NONE           #: No header reading flags
+HDRR_LOADHDRID      = _createrepo_c.HDRR_LOADHDRID      #: Load hdrid
+HDRR_LOADSIGNATURES = _createrepo_c.HDRR_LOADSIGNATURES #: Load siggpg and sigpgp
+HDRR_NOFILEDIGESTS  = _createrepo_c.HDRR_NOFILEDIGESTS  #: Don't load file digests (changes package file tuples from 4 to 3 elements)
+
 #: XML warning - Unknown tag
 XML_WARNING_UNKNOWNTAG  = _createrepo_c.XML_WARNING_UNKNOWNTAG
 

--- a/src/python/createrepo_c/__init__.py
+++ b/src/python/createrepo_c/__init__.py
@@ -314,10 +314,10 @@ class UpdateInfoXmlFile(XmlFile):
 # Functions
 
 def package_from_rpm(filename, checksum_type=SHA256, location_href=None,
-                     location_base=None, changelog_limit=10):
+                     location_base=None, changelog_limit=10, header_reading_flags=HDRR_NONE):
     """:class:`.Package` object from the rpm package"""
     return _createrepo_c.package_from_rpm(filename, checksum_type,
-                      location_href, location_base, changelog_limit)
+                      location_href, location_base, changelog_limit, header_reading_flags)
 
 def xml_from_rpm(filename, checksum_type=SHA256, location_href=None,
                      location_base=None, changelog_limit=10):

--- a/src/python/createrepo_cmodule.c
+++ b/src/python/createrepo_cmodule.c
@@ -305,5 +305,11 @@ PyInit__createrepo_c(void)
     PyModule_AddIntConstant(m, "XML_WARNING_UNKNOWNVAL", CR_XML_WARNING_UNKNOWNVAL);
     PyModule_AddIntConstant(m, "XML_WARNING_BADATTRVAL", CR_XML_WARNING_BADATTRVAL);
 
+    /* Header Reading flags */
+    PyModule_AddIntConstant(m, "HDRR_NONE", CR_HDRR_NONE);
+    PyModule_AddIntConstant(m, "HDRR_LOADHDRID", CR_HDRR_LOADHDRID);
+    PyModule_AddIntConstant(m, "HDRR_LOADSIGNATURES", CR_HDRR_LOADSIGNATURES);
+    PyModule_AddIntConstant(m, "HDRR_NOFILEDIGESTS", CR_HDRR_NOFILEDIGESTS);
+
     return m;
 }

--- a/src/python/parsepkg-py.c
+++ b/src/python/parsepkg-py.c
@@ -36,20 +36,27 @@ py_package_from_rpm(G_GNUC_UNUSED PyObject *self, PyObject *args)
     int checksum_type, changelog_limit;
     char *filename, *location_href, *location_base;
     GError *tmp_err = NULL;
-    cr_HeaderReadingFlags flags = CR_HDRR_NONE; // TODO - support for flags
+    cr_HeaderReadingFlags header_reading_flags = CR_HDRR_NONE;
 
-    if (!PyArg_ParseTuple(args, "sizzi:py_package_from_rpm",
+    if (!PyArg_ParseTuple(args, "sizzi|i:py_package_from_rpm",
                                          &filename,
                                          &checksum_type,
                                          &location_href,
                                          &location_base,
-                                         &changelog_limit)) {
+                                         &changelog_limit,
+                                         &header_reading_flags)) {
+        return NULL;
+    }
+
+    if (header_reading_flags & ~ CR_HDRR_ALL) {
+        PyErr_SetString(PyExc_ValueError, "Unknown header reading flags.");
         return NULL;
     }
 
     pkg = cr_package_from_rpm(filename, checksum_type, location_href,
                               location_base, changelog_limit, NULL,
-                              flags, &tmp_err);
+                              header_reading_flags, &tmp_err);
+
     if (tmp_err) {
         cr_package_free(pkg);
         nice_exception(&tmp_err, "Cannot load %s: ", filename);

--- a/src/python/parsepkg-py.h
+++ b/src/python/parsepkg-py.h
@@ -24,7 +24,7 @@
 
 PyDoc_STRVAR(package_from_rpm__doc__,
 "package_from_rpm(filename, checksum_type, location_href, "
-"location_base, changelog_limit) -> Package\n\n"
+"location_base, changelog_limit[, header_reading_flags]) -> Package\n\n"
 "Package object from the rpm package");
 
 PyObject *py_package_from_rpm(PyObject *self, PyObject *args);

--- a/tests/python/tests/test_package.py
+++ b/tests/python/tests/test_package.py
@@ -232,3 +232,12 @@ class TestCasePackage(unittest.TestCase):
         del(pkg_c)
         self.assertEqual(pkg_d.name, "FooPackage")
         del(pkg_d)
+
+    def test_package_without_digests(self):
+        pkg = cr.package_from_rpm(PKG_ARCHER_PATH, header_reading_flags=cr.HDRR_NOFILEDIGESTS)
+        self.assertTrue(pkg)
+        self.assertEqual(pkg.files, [
+            ('', '/usr/bin/', 'complex_a'),
+            ('dir', '/usr/share/doc/', 'Archer-3.4.5'),
+            ('', '/usr/share/doc/Archer-3.4.5/', 'README')
+            ])


### PR DESCRIPTION
Follow up to https://github.com/rpm-software-management/createrepo_c/pull/362

Add `file_digests` flag to restore old Python API to get files represented as a tuple with 3 values.

Another option could be to expose `cr_HeaderReadingFlags flags` directly. 