### PR TITLE
CI: Run tests from "main" branch of ci-dnf-stack

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -17,6 +17,6 @@ jobs:
       # EPELs fail now for unrelated reasons
       - fedora-all
     fmf_url: https://github.com/rpm-software-management/ci-dnf-stack.git
-    fmf_ref: enable-tmt-dnf-4-stack
+    fmf_ref: main
     tmt_plan: "^/plans/integration/behave-createrepo_c$"
 


### PR DESCRIPTION
We run tests for Fedoras from "enable-tmt-dnf-4-stack" branch of ci-dnf-stack. That branch is intended for using DNF4 over DNF5. But that does not make sense since Fedora now has DNF5 everywhere.

Also the "enable-tmt-dnf-4-stack" branch was missing important fixes from "main" branch and thus some tests were failing (not skipping createrepo_c/delta-rpms.feature on Fedoras).

This patch moves the CI to "main" ci-dnf-stack branch.

This does not interfere with EPEL builds because we do not run them. (We disabled them for a different reason. See commit 5165578f523476d706d6a01d003e296e6064db63.)