### PR TITLE
Configure packit to use caret notation for postrelease snapshots

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -2,6 +2,8 @@
 # https://packit.dev/docs/configuration/
 
 specfile_path: createrepo_c.spec
+version_suffix: "^{PACKIT_PROJECT_SNAPSHOTID}"
+update_release: false
 
 jobs:
   - job: copr_build


### PR DESCRIPTION
This ensures the build of that specific version is considered newer than any other regular release of it.

For rpm-software-management/ci-dnf-stack#1843

Example build: https://copr.fedorainfracloud.org/coprs/amatej/dnf-nightly/build/10282462/