### PR TITLE
doc: Fix a link to Packit documentation

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,5 +1,5 @@
 # See the documentation for more information:
-# https://packit.dev/docs/configuration/
+# https://packit.dev/docs/configuration
 
 specfile_path: createrepo_c.spec
 


### PR DESCRIPTION
The address with a trailing slash returns 404 HTTP error.