### PR TITLE
add support for external checksums file

### DIFF
--- a/src/checksum.c
+++ b/src/checksum.c
@@ -105,6 +105,32 @@ cr_checksum_name_str(cr_ChecksumType type)
     }
 }
 
+size_t
+cr_checksum_raw_size(cr_ChecksumType type)
+{
+    switch (type) {
+    case CR_CHECKSUM_UNKNOWN:
+        return 0;
+#ifdef WITH_LEGACY_HASHES
+    case CR_CHECKSUM_MD5:
+        return 16;
+    case CR_CHECKSUM_SHA:
+    case CR_CHECKSUM_SHA1:
+        return 20;
+#endif
+    case CR_CHECKSUM_SHA224:
+        return 28;
+    case CR_CHECKSUM_SHA256:
+        return 32;
+    case CR_CHECKSUM_SHA384:
+        return 48;
+    case CR_CHECKSUM_SHA512:
+        return 64;
+    default:
+        return 0;
+    }
+}
+
 char *
 cr_checksum_file(const char *filename,
                  cr_ChecksumType type,
@@ -265,12 +291,10 @@ cr_checksum_update(cr_ChecksumCtx *ctx,
     return CRE_OK;
 }
 
-char *
-cr_checksum_final(cr_ChecksumCtx *ctx, GError **err)
+size_t
+cr_checksum_final_raw(cr_ChecksumCtx *ctx, unsigned char *raw_checksum, GError **err)
 {
     unsigned int len;
-    unsigned char raw_checksum[EVP_MAX_MD_SIZE];
-    char *checksum;
 
     assert(ctx);
     assert(!err || *err == NULL);
@@ -278,18 +302,25 @@ cr_checksum_final(cr_ChecksumCtx *ctx, GError **err)
     if (!EVP_DigestFinal_ex(ctx->ctx, raw_checksum, &len)) {
         g_set_error(err, ERR_DOMAIN, CRE_OPENSSL,
                     "EVP_DigestFinal_ex() failed");
-        EVP_MD_CTX_destroy(ctx->ctx);
-        g_free(ctx);
-        return NULL;
+        len = 0;
     }
-
     EVP_MD_CTX_destroy(ctx->ctx);
+    g_free(ctx);
+    return len;
+}
 
-    checksum = g_malloc0(sizeof(char) * (len * 2 + 1));
+char *
+cr_checksum_final(cr_ChecksumCtx *ctx, GError **err)
+{
+    unsigned char raw_checksum[EVP_MAX_MD_SIZE];
+    size_t len = cr_checksum_final_raw(ctx, raw_checksum, err);
+
+    if (!len)
+        return NULL;
+
+    char *checksum = g_malloc0(sizeof(char) * (len * 2 + 1));
     for (size_t x = 0; x < len; x++)
         sprintf(checksum+(x*2), "%02x", raw_checksum[x]);
-
-    g_free(ctx);
 
     return checksum;
 }

--- a/src/checksum.h
+++ b/src/checksum.h
@@ -67,6 +67,12 @@ const char *cr_checksum_name_str(cr_ChecksumType type);
  */
 cr_ChecksumType cr_checksum_type(const char *name);
 
+/** Return size of raw checksum
+ * @param type          checksum type
+ * @return              size of raw checksum or 0 on error
+ */
+size_t cr_checksum_raw_size(cr_ChecksumType type);
+
 /** Compute file checksum.
  * @param filename      filename
  * @param type          type of checksum
@@ -104,6 +110,14 @@ int cr_checksum_update(cr_ChecksumCtx *ctx,
  * @return          Checksum string or NULL on error.
  */
 char *cr_checksum_final(cr_ChecksumCtx *ctx, GError **err);
+
+/** Finalize checksum calculation, fill raw_checksum buffer and return checksum length.
+ * Free all checksum context resources.
+ * @param ctx       Checksum context.
+ * @param err       GError **
+ * @return          Raw checksum length or 0 on error.
+ */
+size_t cr_checksum_final_raw(cr_ChecksumCtx *ctx, unsigned char *raw_checksum, GError **err);
 
 /** @} */
 

--- a/src/createrepo_c.c
+++ b/src/createrepo_c.c
@@ -329,6 +329,89 @@ fill_pool(GThreadPool *pool,
     return *task_count;
 }
 
+static guint
+checksum_hash_func(gconstpointer key)
+{
+    const unsigned char *kd = key;
+    /* the input is already a hash, so we just return the first 4 bytes as integer */
+    return kd[0] << 24 | kd[1] << 16 | kd[2] << 8 | kd[3];
+}
+
+static gboolean
+checksum_hash_equal(gconstpointer a,
+                    gconstpointer b)
+{
+    return memcmp((const void *)a, (const void *)b, 16) == 0 ? TRUE : FALSE;
+}
+
+
+static gboolean
+create_checksum_hextobin(const char *in, unsigned char *out, size_t len)
+{
+    for (size_t i = 0; i < len; i++, in += 2) {
+        int v1 = g_ascii_xdigit_value(in[0]);
+        if (v1 == -1)
+            return FALSE;
+        int v2 = g_ascii_xdigit_value(in[1]);
+        if (v2 == -1)
+            return FALSE;
+        *out++ = (v1 << 4) | v2;
+    }
+    return TRUE;
+}
+
+/** Create hash table of file checksums
+ * Called only if the CREATEREPO_CHECKSUMS environment variable is set to a file
+ * containing checksums.
+ *
+ * @param fp                File handle of opened checksums file
+ * @param checksum_type     Checksum type we need to generate
+ * @return                  Hash table filled with checksums
+ */
+static GHashTable *
+create_checksum_hash(FILE *fp,
+                     cr_ChecksumType checksum_type)
+{
+    if (!fp)
+        return NULL;
+
+#ifdef WITH_LEGACY_HASHES
+    if (checksum_type == CR_CHECKSUM_SHA)
+        checksum_type = CR_CHECKSUM_SHA1;
+#endif
+    size_t checksum_size = cr_checksum_raw_size(checksum_type);
+    if (!checksum_size)
+        return NULL;
+    const char *checksum_type_str = cr_checksum_name_str(checksum_type);
+    size_t checksum_type_str_len = strlen(checksum_type_str);
+
+    GHashTable *checksum_hash = g_hash_table_new_full(checksum_hash_func, checksum_hash_equal, g_free, NULL);
+
+    char *line = NULL, *lp;
+    size_t len = 0;
+    ssize_t r;
+    while ((r = getline(&line, &len, fp)) != -1) {
+        if (r < 32)
+	  continue;
+        for (lp = strchr(line + 32, ':'); lp; lp = strchr(lp + 1, ':'))
+            if (!strncmp(lp - checksum_type_str_len, checksum_type_str, checksum_type_str_len))
+                break;
+        if (!lp)
+            continue;
+        unsigned char *keyvalue = g_malloc(16 + checksum_size);
+        if (!create_checksum_hextobin(line, keyvalue, 16)) {
+            g_free(keyvalue);
+        } else if (!create_checksum_hextobin(lp + 1, keyvalue + 16, checksum_size)) {
+            g_free(keyvalue);
+        } else {
+            g_hash_table_replace(checksum_hash, keyvalue, keyvalue + 16);
+        }
+    }
+    if (line)
+        free(line);
+    return checksum_hash;
+}
+
 
 /** Prepare cache dir for checksums.
  * Called only if --cachedir options is used.
@@ -1444,6 +1527,18 @@ main(int argc, char **argv)
         }
     }
 
+    GHashTable *checksum_hash = NULL;
+    const char *checksum_hash_file = getenv("CREATEREPO_CHECKSUMS");
+    if (checksum_hash_file) {
+        FILE *checksum_file_fp = fopen(checksum_hash_file, "r");
+        if (checksum_file_fp) {
+            checksum_hash = create_checksum_hash(checksum_file_fp, cmd_options->checksum_type);
+            fclose(checksum_file_fp);
+        } else {
+            g_warning("Cannot open checksum file %s: %s", checksum_hash_file, g_strerror(errno));
+        }
+    }
+
     // Thread pool - User data initialization
     user_data.pri_f             = pri_cr_file;
     user_data.fil_f             = fil_cr_file;
@@ -1483,6 +1578,7 @@ main(int argc, char **argv)
 
     user_data.cut_dirs          = cmd_options->cut_dirs;
     user_data.location_prefix   = cmd_options->location_prefix;
+    user_data.checksum_hash     = checksum_hash;
     user_data.had_errors        = 0;
     user_data.output_pkg_list   = output_pkg_list;
 
@@ -1569,6 +1665,10 @@ main(int argc, char **argv)
 
     g_message("Pool finished%s", (user_data.had_errors ? " with errors" : ""));
 
+    if (checksum_hash) {
+        g_hash_table_destroy(checksum_hash);
+        checksum_hash = NULL;
+    }
     cr_xml_dump_cleanup();
 
     if (output_pkg_list)

--- a/src/dumper_thread.c
+++ b/src/dumper_thread.c
@@ -439,6 +439,47 @@ prepare_split_media_baseurl(int media_id, const char *location_base)
     return g_strdup_printf("%s#%d", tmp_location_base, media_id);
 }
 
+static char *
+get_checksum_from_hash(const char *filename,
+                       cr_ChecksumType type,
+                       GHashTable *checksum_hash,
+                       unsigned int header_start)
+{
+    FILE *fp = fopen(filename, "rb");
+    if (!fp)
+        return NULL;
+    char *buf = g_malloc(header_start);
+    if (fread(buf, header_start, 1, fp) != 1) {
+        g_free(buf);
+        fclose(fp);
+        return NULL;
+    }
+#ifdef WITH_LEGACY_HASHES
+    cr_ChecksumCtx *ctx = cr_checksum_new(CR_CHECKSUM_MD5, NULL);
+    if (ctx)
+        cr_checksum_update(ctx, buf, header_start, NULL);
+    g_free(buf);
+    fclose(fp);
+    if (!ctx)
+        return NULL;
+#endif
+    unsigned char raw_key_checksum[16];
+    if (cr_checksum_final_raw(ctx, raw_key_checksum, NULL) != sizeof(raw_key_checksum))
+        return NULL;
+    unsigned char *raw_checksum = g_hash_table_lookup(checksum_hash, raw_key_checksum);
+    if (!raw_checksum)
+        return NULL;
+    size_t checksum_size = cr_checksum_raw_size(type);
+    if (!checksum_size)
+        return NULL;
+    char * checksum = g_malloc0(sizeof(char) * (checksum_size * 2 + 1));
+    for (size_t x = 0; x < checksum_size; x++)
+        sprintf(checksum+(x*2), "%02x", raw_checksum[x]);
+    return checksum;
+}
+
+
+
 static cr_Package *
 load_rpm(const char *fullpath,
          cr_ChecksumType checksum_type,
@@ -448,6 +489,7 @@ load_rpm(const char *fullpath,
          int changelog_limit,
          struct stat *stat_buf,
          cr_HeaderReadingFlags hdrrflags,
+         GHashTable *checksum_hash,
          GError **err)
 {
     cr_Package *pkg = NULL;
@@ -488,7 +530,11 @@ load_rpm(const char *fullpath,
     }
 
     // Compute checksum
-    char *checksum = get_checksum(fullpath, checksum_type, pkg,
+    char *checksum = NULL;
+    if (checksum_hash)
+        checksum = get_checksum_from_hash(fullpath, checksum_type, checksum_hash, hdr_r.start);
+    if (!checksum)
+        checksum = get_checksum(fullpath, checksum_type, pkg,
                                   checksum_cachedir, &tmp_err);
     if (!checksum) {
         g_propagate_error(err, tmp_err);
@@ -640,7 +686,7 @@ cr_dumper_thread(gpointer data, gpointer user_data)
         pkg = load_rpm(task->full_path, udata->checksum_type,
                        udata->checksum_cachedir, location_href,
                        location_base, udata->changelog_limit,
-                       NULL, hdrrflags, &tmp_err);
+                       NULL, hdrrflags, udata->checksum_hash, &tmp_err);
         assert(pkg || tmp_err);
 
         if (!pkg) {

--- a/src/dumper_thread.h
+++ b/src/dumper_thread.h
@@ -72,6 +72,7 @@ struct UserData {
     const char *checksum_type_str;  // Name of selected checksum
     cr_ChecksumType checksum_type;  // Constant representing selected checksum
     const char *checksum_cachedir;  // Dir with cached checksums
+    GHashTable *checksum_hash;      // Hash with checksums read from file
     gboolean skip_symlinks;         // Skip symlinks
     gboolean filelists_ext;         // Include hashes (and create filelists-ext.*)
     long task_count;                // Total number of tasks to process


### PR DESCRIPTION
With this patch createrepo_c will process pre-built checksum lists taken from the evironment variable `CREATEREPO_CHECKSUMS`. 
If a package was found in the list the checksum is taken from the list instead of creating the checksum of the package.
This can speed up createrepo_c significantly and reduce IO load in build environments which provide those pre-built lists.