### PR TITLE
2.0.0: Hide mergerepo_c header, adapt koji API

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,7 +38,6 @@ SET(headers
     checksum.h
     compression_wrapper.h
     constants.h
-    mergerepo_c.h
     createrepo_c.h
     createrepo_shared.h
     deltarpms.h

--- a/src/koji.c
+++ b/src/koji.c
@@ -97,7 +97,9 @@ pkgorigins_prepare(struct KojiMergedReposStuff **koji_stuff_ptr,
 
 int
 koji_stuff_prepare(struct KojiMergedReposStuff **koji_stuff_ptr,
-                   struct CmdOptions *cmd_options,
+                   const char * blocked,
+                   gboolean koji_simple,
+                   const char * tmp_out_repo,
                    GSList *repos)
 {
     struct KojiMergedReposStuff *koji_stuff;
@@ -126,13 +128,13 @@ koji_stuff_prepare(struct KojiMergedReposStuff **koji_stuff_ptr,
 
     // Load list of blocked srpm packages
 
-    if (cmd_options->blocked) {
+    if (blocked) {
         int x = 0;
         char *content = NULL;
         char **names;
         GError *err = NULL;
 
-        if (!g_file_get_contents(cmd_options->blocked, &content, NULL, &err)) {
+        if (!g_file_get_contents(blocked, &content, NULL, &err)) {
             g_critical("Error while reading blocked file: %s", err->message);
             g_error_free(err);
             g_free(content);
@@ -157,10 +159,10 @@ koji_stuff_prepare(struct KojiMergedReposStuff **koji_stuff_ptr,
     }
 
 
-    koji_stuff->simple = cmd_options->koji_simple;
+    koji_stuff->simple = koji_simple;
 
     // Prepare pkgorigin file
-    result = pkgorigins_prepare_file (cmd_options->tmp_out_repo,
+    result = pkgorigins_prepare_file (tmp_out_repo,
                                       &koji_stuff->pkgorigins);
     if (result != 0) {
         return result;

--- a/src/koji.h
+++ b/src/koji.h
@@ -87,7 +87,9 @@ pkgorigins_prepare(struct KojiMergedReposStuff **koji_stuff_ptr,
 
 int
 koji_stuff_prepare(struct KojiMergedReposStuff **koji_stuff_ptr,
-                   struct CmdOptions *cmd_options,
+                   const char * blocked,
+                   gboolean koji_simple,
+                   const char * tmp_out_repo,
                    GSList *repos);
 
 void

--- a/src/mergerepo_c.c
+++ b/src/mergerepo_c.c
@@ -2119,7 +2119,8 @@ main(int argc, char **argv)
 
     struct KojiMergedReposStuff *koji_stuff = NULL;
     if (cmd_options->koji)
-        koji_stuff_prepare(&koji_stuff, cmd_options, local_repos);
+        koji_stuff_prepare(&koji_stuff, cmd_options->blocked, cmd_options->koji_simple,
+                           cmd_options->tmp_out_repo, local_repos);
     else if (cmd_options->pkgorigins)
         pkgorigins_prepare(&koji_stuff, cmd_options->tmp_out_repo);
 

--- a/tests/test_koji.c
+++ b/tests/test_koji.c
@@ -31,7 +31,6 @@ test_koji_stuff_00(void)
     gchar *template = g_strdup(TMPDIR_TEMPLATE);
     gchar *tmp = g_strconcat(mkdtemp(template), "/", NULL);
     struct KojiMergedReposStuff *koji_stuff = NULL;
-    struct CmdOptions o = {.koji=1, .koji_simple=1, .blocked=NULL, .tmp_out_repo=tmp};
 
     GSList *local_repos = NULL;
     struct cr_MetadataLocation *loc = cr_locate_metadata((gchar *) TEST_REPO_00, TRUE, NULL);
@@ -43,7 +42,7 @@ test_koji_stuff_00(void)
     loc = cr_locate_metadata((gchar *) TEST_REPO_KOJI_01, TRUE, NULL);
     local_repos = g_slist_prepend(local_repos, loc);
 
-    int ret = koji_stuff_prepare(&koji_stuff, &o, local_repos);
+    int ret = koji_stuff_prepare(&koji_stuff, NULL, 1, tmp, local_repos);
     g_assert_cmpint(ret, ==, 0);
 
     //we have only 3 uniq srpm names
@@ -79,7 +78,6 @@ test_koji_stuff_01(void)
     fclose(blocked);
 
     struct KojiMergedReposStuff *koji_stuff = NULL;
-    struct CmdOptions o = {.koji=0, .blocked=blocked_files_path, .tmp_out_repo=tmp};
 
     GSList *local_repos = NULL;
     struct cr_MetadataLocation *loc = cr_locate_metadata((gchar *) TEST_REPO_00, TRUE, NULL);
@@ -91,7 +89,7 @@ test_koji_stuff_01(void)
     loc = cr_locate_metadata((gchar *) TEST_REPO_KOJI_01, TRUE, NULL);
     local_repos = g_slist_prepend(local_repos, loc);
 
-    int ret = koji_stuff_prepare(&koji_stuff, &o, local_repos);
+    int ret = koji_stuff_prepare(&koji_stuff, blocked_files_path, 0, tmp, local_repos);
     g_assert_cmpint(ret, ==, 0);
 
     //we have only 3 uniq srpm names
@@ -129,13 +127,12 @@ test_koji_stuff_02_get_newest_srpm_from_one_repo(void)
     gchar *tmp = g_strconcat(mkdtemp(template), "/", NULL);
 
     struct KojiMergedReposStuff *koji_stuff = NULL;
-    struct CmdOptions o = {.koji=0, .blocked=NULL, .tmp_out_repo=tmp};
 
     GSList *local_repos = NULL;
     struct cr_MetadataLocation *loc = cr_locate_metadata((gchar *) TEST_REPO_KOJI_01, TRUE, NULL);
     local_repos = g_slist_prepend(local_repos, loc);
 
-    int ret = koji_stuff_prepare(&koji_stuff, &o, local_repos);
+    int ret = koji_stuff_prepare(&koji_stuff, NULL, 0, tmp, local_repos);
     g_assert_cmpint(ret, ==, 0);
 
     g_assert_cmpint(g_hash_table_size(koji_stuff->include_srpms), ==, 1);
@@ -157,7 +154,6 @@ test_koji_stuff_03_get_srpm_from_first_repo_even_if_its_older(void)
     gchar *tmp = g_strconcat(mkdtemp(template), "/", NULL);
 
     struct KojiMergedReposStuff *koji_stuff = NULL;
-    struct CmdOptions o = {.koji=0, .blocked=NULL, .tmp_out_repo=tmp};
 
     GSList *local_repos = NULL;
     struct cr_MetadataLocation *loc = cr_locate_metadata((gchar *) TEST_REPO_KOJI_01, TRUE, NULL);
@@ -165,7 +161,7 @@ test_koji_stuff_03_get_srpm_from_first_repo_even_if_its_older(void)
     loc = cr_locate_metadata((gchar *) TEST_REPO_KOJI_02, TRUE, NULL);
     local_repos = g_slist_prepend(local_repos, loc);
 
-    int ret = koji_stuff_prepare(&koji_stuff, &o, local_repos);
+    int ret = koji_stuff_prepare(&koji_stuff, NULL, 0, tmp, local_repos);
     g_assert_cmpint(ret, ==, 0);
 
     g_assert_cmpint(g_hash_table_size(koji_stuff->include_srpms), ==, 1);


### PR DESCRIPTION
Neither mergerepo_c.h nor koji.h should have been public. To preserve functionality keep adapted koji.h but hide unused mergerepo_c.h.