### PR TITLE
Extend the CI to test the sdist build backend

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -15,10 +15,13 @@ jobs:
           sudo dnf -y install dnf-plugins-core python3-pip
           sudo dnf -y builddep createrepo_c.spec
           pip install --upgrade pip
-          pip install pytest
+          pip install pytest build
 
       - name: Compile and Install
         run: pip install .
+
+      - name: Compile / build both sdist and bdist  # exercises different build codepaths - more similar to what cibuildwheel executes
+        run: python3 -m build
 
       - name: Test
         run: pytest --verbose --color=yes tests/python/tests/

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -55,16 +55,7 @@ jobs:
         python-version: '3.x'
 
     - name: Build wheels for CPython
-      uses: pypa/cibuildwheel@v3.3.1
-      env:
-        CIBW_ARCHS: auto64
-        CIBW_SKIP: "pp* *-musllinux_*"  # no PyPy or musl builds
-        CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28  # alma 8
-        CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
-        CIBW_BEFORE_ALL_LINUX: dnf -y install epel-release && yes | dnf -y builddep createrepo_c.spec
-        CIBW_TEST_REQUIRES: pytest
-        CIBW_TEST_COMMAND: |
-          pytest --verbose --color=yes {project}/tests/python/tests/
+      uses: pypa/cibuildwheel@v3.4.1
 
     - uses: actions/upload-artifact@v6
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ _CPack_Packages/
 src/version.h
 src/createrepo_c.pc
 src/deltarpms.h
-src/python/createrepo_c/
 _skbuild/
 
 # Python distribution stuff

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ _skbuild/
 
 # Python distribution stuff
 dist/
+wheelhouse/
 MANIFEST
 *.egg-info/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,17 @@ mergerepo_c = "createrepo_c:mergerepo_c"
 modifyrepo_c = "createrepo_c:modifyrepo_c"
 sqliterepo_c = "createrepo_c:sqliterepo_c"
 
+[tool.cibuildwheel]
+build = "cp3{11,12,13,14}-manylinux_*"
+archs = ["auto64"]  # add "aarch64" if running outside of CI
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
+before-all = "dnf -y install epel-release && yes | dnf -y builddep createrepo_c.spec"
+before-build = "python -m pip install scikit-build-core"
+container-engine = "podman"
+test-requires = "pytest"
+test-command = "pytest --verbose --color=yes {project}/tests/python/tests/"
+
 [tool.scikit-build]
 cmake.args = [
     "-DBIN_INSTALL_DIR:PATH=createrepo_c/data/bin",


### PR DESCRIPTION
They are slightly different - `pip install .` was working yet `python3 -m build` was not.

Resolved by removing the python module folder from .gitignore.

The `pyproject.toml` change is not relevant but it does make manual `cibuildwheel` runs much easier.